### PR TITLE
Update generated views and triggers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ inherits = "release"
 lto = false
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "co.powersync"
-version = "0.1.4"
+version = "0.1.5"
 description = "PowerSync Core SQLite Extension"
 
 repositories {

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -44,6 +44,7 @@ pub fn extract_table_info(db: *mut sqlite::sqlite3, data: &str) -> Result<Manage
     // language=SQLite
     let statement = db.prepare_v2("SELECT
         json_extract(?1, '$.name') as name,
+        ifnull(json_extract(?1, '$.view_name'), json_extract(?1, '$.name')) as view_name,
         json_extract(?1, '$.local_only') as local_only,
         json_extract(?1, '$.insert_only') as insert_only")?;
     statement.bind_text(1, data, sqlite::Destructor::STATIC)?;

--- a/crates/core/src/views.rs
+++ b/crates/core/src/views.rs
@@ -22,9 +22,10 @@ fn powersync_view_sql_impl(
     let statement = extract_table_info(db, table)?;
 
     let name = statement.column_text(0)?;
-    let local_only = statement.column_int(1)? != 0;
+    let view_name = statement.column_text(1)?;
+    let local_only = statement.column_int(2)? != 0;
 
-    let quoted_name = quote_identifier(name);
+    let quoted_name = quote_identifier(view_name);
     let internal_name = quote_internal_name(name, local_only);
 
     let stmt2 = db.prepare_v2("select json_extract(e.value, '$.name') as name, json_extract(e.value, '$.type') as type from json_each(json_extract(?, '$.columns')) e")?;
@@ -68,12 +69,13 @@ fn powersync_trigger_delete_sql_impl(
     let statement = extract_table_info(ctx.db_handle(), table)?;
 
     let name = statement.column_text(0)?;
-    let local_only = statement.column_int(1)? != 0;
-    let insert_only = statement.column_int(2)? != 0;
+    let view_name = statement.column_text(1)?;
+    let local_only = statement.column_int(2)? != 0;
+    let insert_only = statement.column_int(3)? != 0;
 
-    let quoted_name = quote_identifier(name);
+    let quoted_name = quote_identifier(view_name);
     let internal_name = quote_internal_name(name, local_only);
-    let trigger_name = quote_identifier_prefixed("ps_view_delete_", name);
+    let trigger_name = quote_identifier_prefixed("ps_view_delete_", view_name);
     let type_string = quote_string(name);
 
     return if !local_only && !insert_only {
@@ -125,12 +127,13 @@ fn powersync_trigger_insert_sql_impl(
     let statement = extract_table_info(ctx.db_handle(), table)?;
 
     let name = statement.column_text(0)?;
-    let local_only = statement.column_int(1)? != 0;
-    let insert_only = statement.column_int(2)? != 0;
+    let view_name = statement.column_text(1)?;
+    let local_only = statement.column_int(2)? != 0;
+    let insert_only = statement.column_int(3)? != 0;
 
-    let quoted_name = quote_identifier(name);
+    let quoted_name = quote_identifier(view_name);
     let internal_name = quote_internal_name(name, local_only);
-    let trigger_name = quote_identifier_prefixed("ps_view_insert_", name);
+    let trigger_name = quote_identifier_prefixed("ps_view_insert_", view_name);
     let type_string = quote_string(name);
 
     let local_db = ctx.db_handle();
@@ -208,12 +211,13 @@ fn powersync_trigger_update_sql_impl(
     let statement = extract_table_info(ctx.db_handle(), table)?;
 
     let name = statement.column_text(0)?;
-    let local_only = statement.column_int(1)? != 0;
-    let insert_only = statement.column_int(2)? != 0;
+    let view_name = statement.column_text(1)?;
+    let local_only = statement.column_int(2)? != 0;
+    let insert_only = statement.column_int(3)? != 0;
 
-    let quoted_name = quote_identifier(name);
+    let quoted_name = quote_identifier(view_name);
     let internal_name = quote_internal_name(name, local_only);
-    let trigger_name = quote_identifier_prefixed("ps_view_update_", name);
+    let trigger_name = quote_identifier_prefixed("ps_view_update_", view_name);
     let type_string = quote_string(name);
 
     let db = ctx.db_handle();

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.1.4'
+  s.version          = '0.1.5'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.


### PR DESCRIPTION
This backports updates from the powersync.dart:
1. https://github.com/powersync-ja/powersync.dart/pull/20 - Allow overriding view names by adding a `view_name` field in the table json.
2. https://github.com/powersync-ja/powersync.dart/pull/39

Schema validations are not implemented here yet - these currently have to be implemented in the respective SDKs.

Tests from powersync.dart are passing on this branch (have to manually build and load the libpowersync.so): https://github.com/powersync-ja/powersync.dart/tree/rust-lib