### PR TITLE
Add missing xcframework properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "powersync_core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bytes",
  "num-derive",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "cc",
  "powersync_core",
@@ -331,7 +331,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "sqlite3"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]
 license = "Apache-2.0"
 homepage = "https://powersync.co"
-repository = "https://github.com/journeyapps/powersync-sqlite-core"
+repository = "https://github.com/powersync-ja/powersync-sqlite-core"
 
 [workspace.dependencies]
 sqlite_nostd = { path="./sqlite-rs-embedded/sqlite_nostd" }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,6 +5,8 @@ Bump the version number in these places:
 1. Cargo.toml
 2. powersync-sqlite-core.podspec.
 3. android/build.gradle.kts
+4. build-pod.sh - CFBundleVersion and CFBundleShortVersionString.
+5. `cargo build` to update Cargo.lock
 
 Create a tag:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,8 +27,7 @@ The above does the following:
 
 1. Create a draft GitHub release.
 2. Build the xcframework for iOS and macOS, and upload to GitHub (attached to the above release).
-3. Publish the cocoapod for iOS and macOS.
-4. Build and publish an Android aar to Sonatype staging.
+3. Build and publish an Android aar to Sonatype staging.
 
 Once that is done, go to the Maven staging repository, and "Close", wait, and "Release" the
 repository:
@@ -38,3 +37,9 @@ https://s01.oss.sonatype.org/#stagingRepositories
 Docs: https://central.sonatype.org/publish/release/
 
 Go to GitHub Releases on the repository, update the description, then "Publish Release".
+
+Publish the cocoapod:
+
+```sh
+pod trunk push powersync-sqlite-core.podspec
+```

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -125,7 +125,7 @@ publishing {
         if (System.getenv("GITHUB_ACTOR") != null) {
             maven {
                 name = "GitHubPackages"
-                url = uri("https://maven.pkg.github.com/journeyapps/powersync-sqlite-core")
+                url = uri("https://maven.pkg.github.com/powersync-ja/powersync-sqlite-core")
                 credentials {
                     username = System.getenv("GITHUB_ACTOR")
                     password = System.getenv("GITHUB_TOKEN")

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -84,7 +84,7 @@ publishing {
             pom {
                 name.set(project.name)
                 description.set(project.description)
-                url.set("https://github.com/journeyapps/powersync-sqlite-core")
+                url.set("https://github.com/powersync-ja/powersync-sqlite-core")
 
                 developers {
                     developer {
@@ -102,9 +102,9 @@ publishing {
                 }
 
                 scm {
-                    connection.set("scm:git:github.com/journeyapps/powersync-sqlite-core.git")
-                    developerConnection.set("scm:git:ssh://github.com/journeyapps/powersync-sqlite-core.git")
-                    url.set("https://github.com/journeyapps/powersync-sqlite-core")
+                    connection.set("scm:git:github.com/powersync-ja/powersync-sqlite-core.git")
+                    developerConnection.set("scm:git:ssh://github.com/powersync-ja/powersync-sqlite-core.git")
+                    url.set("https://github.com/powersync-ja/powersync-sqlite-core")
                 }
             }
         }

--- a/build-pod.sh
+++ b/build-pod.sh
@@ -25,6 +25,8 @@ function createXcframework() {
   <string>FMWK</string>
   <key>CFBundleSignature</key>
   <string>????</string>
+  <key>MinimumOSVersion</key>
+  <string>11.0</string>
 </dict>
 </plist>
 EOF

--- a/build-pod.sh
+++ b/build-pod.sh
@@ -27,6 +27,10 @@ function createXcframework() {
   <string>????</string>
   <key>MinimumOSVersion</key>
   <string>11.0</string>
+  <key>CFBundleVersion</key>
+  <string>0.1.5</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.1.5</string>
 </dict>
 </plist>
 EOF

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -6,11 +6,11 @@ Pod::Spec.new do |s|
 PowerSync extension for SQLite.
                        DESC
 
-  s.homepage         = 'https://github.com/journeyapps/powersync-sqlite-core'
+  s.homepage         = 'https://github.com/powersync-ja/powersync-sqlite-core'
   s.license          = 'Apache License, Version 2.0'
   s.author           = 'Journey Mobile, Inc.'
 
-  s.source   = { :http => "https://github.com/journeyapps/powersync-sqlite-core/releases/download/v#{s.version}/powersync-sqlite-core.xcframework.tar.xz" }
+  s.source   = { :http => "https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v#{s.version}/powersync-sqlite-core.xcframework.tar.xz" }
   s.vendored_frameworks  = 'powersync-sqlite-core.xcframework'
 
 


### PR DESCRIPTION
Reported issue when submitting to App Store / TestFlight:

```
[logs] ERROR: [ContentDelivery.Uploader] Asset validation failed (90530) Invalid MinimumOSVersion. Apps that only support 64-bit devices must specify a deployment target of 8.0 or later. MinimumOSVersion in 'abc.app/Frameworks/powersync-sqlite-core.framework' is ''.
[logs] ERROR: [ContentDelivery.Uploader] Asset validation failed (90360) Missing Info.plist value. A value for the key 'MinimumOSVersion' in bundle abc.app/Frameworks/powersync-sqlite-core.framework is required.
[logs] ERROR: [ContentDelivery.Uploader] Asset validation failed (90057) The bundle 'Payload/abc.app/Frameworks/powersync-sqlite-core.framework' is missing plist key. The Info.plist file is missing the required key: CFBundleShortVersionString. Please find more information about CFBundleShortVersionString at https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring
[logs] ERROR: [ContentDelivery.Uploader] Asset validation failed (90056) This bundle Payload/abc.app/Frameworks/powersync-sqlite-core.framework is invalid. The Info.plist file is missing the required key: CFBundleVersion. Please find more information about CFBundleVersion at https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion
[logs] ERROR: [ContentDelivery.Uploader] Asset validation failed (90208) Invalid Bundle. The bundle abc.app/Frameworks/powersync-sqlite-core.framework does not support the minimum OS Version specified in the Info.plist.
```

Fixes #4.

Also fixes a couple of release-related issues.

# 