### PR TITLE
Correctly use view_name override if provided

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "powersync_core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bytes",
  "num-derive",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "cc",
  "powersync_core",
@@ -331,7 +331,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "sqlite3"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ inherits = "release"
 lto = false
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]
 license = "Apache-2.0"
-homepage = "https://powersync.co"
+homepage = "https://powersync.com"
 repository = "https://github.com/powersync-ja/powersync-sqlite-core"
 
 [workspace.dependencies]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "co.powersync"
-version = "0.1.5"
+version = "0.1.6"
 description = "PowerSync Core SQLite Extension"
 
 repositories {

--- a/build-pod.sh
+++ b/build-pod.sh
@@ -28,9 +28,9 @@ function createXcframework() {
   <key>MinimumOSVersion</key>
   <string>11.0</string>
   <key>CFBundleVersion</key>
-  <string>0.1.5</string>
+  <string>0.1.6</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.1.5</string>
+  <string>0.1.6</string>
 </dict>
 </plist>
 EOF

--- a/crates/core/src/schema_management.rs
+++ b/crates/core/src/schema_management.rs
@@ -205,7 +205,7 @@ delete_trigger_sql = gen.delete_trigger_sql,
 insert_trigger_sql = gen.insert_trigger_sql,
 update_trigger_sql = gen.update_trigger_sql
 FROM (SELECT
-      json_extract(json_each.value, '$.name') as name,
+      ifnull(json_extract(json_each.value, '$.view_name'), json_extract(json_each.value, '$.name')) as name,
                    powersync_view_sql(json_each.value) as sql,
                    powersync_trigger_delete_sql(json_each.value) as delete_trigger_sql,
                    powersync_trigger_insert_sql(json_each.value) as insert_trigger_sql,
@@ -229,7 +229,7 @@ INSERT INTO powersync_views(
     update_trigger_sql
 )
 SELECT
-json_extract(json_each.value, '$.name') as name,
+ifnull(json_extract(json_each.value, '$.view_name'), json_extract(json_each.value, '$.name')) as name,
              powersync_view_sql(json_each.value) as sql,
              powersync_trigger_delete_sql(json_each.value) as delete_trigger_sql,
              powersync_trigger_insert_sql(json_each.value) as insert_trigger_sql,
@@ -241,7 +241,7 @@ json_extract(json_each.value, '$.name') as name,
     // language=SQLite
     db.exec_text("\
 DELETE FROM powersync_views WHERE name NOT IN (
-    SELECT json_extract(json_each.value, '$.name')
+    SELECT ifnull(json_extract(json_each.value, '$.view_name'), json_extract(json_each.value, '$.name'))
                         FROM json_each(json_extract(?, '$.tables'))
             )", schema).into_db_result(db)?;
 

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.1.5'
+  s.version          = '0.1.6'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.


### PR DESCRIPTION
Bug: Using explicit viewName overrides (added in #3) could cause view "..." already exists errors.

Fixes the same issue as in https://github.com/powersync-ja/powersync.dart/pull/57.
