### PR TITLE
Update iOS toolchain architecture to aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,8 @@ jobs:
 
       - name: Setup
         run: |
-          rustup toolchain install nightly-2024-05-18-x86_64-apple-darwin
-          rustup component add rust-src --toolchain nightly-2024-05-18-x86_64-apple-darwin
+          rustup toolchain install nightly-2024-05-18-aarch64-apple-darwin
+          rustup component add rust-src --toolchain nightly-2024-05-18-aarch64-apple-darwin
           rustup target add \
             x86_64-apple-darwin \
             aarch64-apple-darwin \


### PR DESCRIPTION
## Work done

- Update iOS toolchain architecture to `aarch64` for github runners using `macos-latest`