### PR TITLE
Enable linux arm64 builds

### DIFF
--- a/.github/workflows/actions/upload.yml
+++ b/.github/workflows/actions/upload.yml
@@ -1,0 +1,24 @@
+name: "Upload binary file"
+description: "Upload binary file to GitHub releases"
+inputs:
+  repo-token:
+    required: true
+    description: "The secret created for the workflow run"
+  file-name:
+    required: true
+    description: "The file name to be uploaded"
+  tag:
+    required: false
+    description: "The short ref name of the branch or tag that triggered the workflow run."
+    default: ${{ github.ref_name }}
+runs:
+  using: "composite"
+  steps:
+    - name: Upload binary
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ inputs.repo-token }}
+        overwrite: true
+        file: ${{ inputs.file-name }}
+        asset_name: ${{ inputs.file-name }}
+        tag: ${{ inputs.tag }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,7 @@ on:
   push:
     tags:
       - "*"
+  workflow_dispatch:
 name: "linux"
 jobs:
   build_x86_64:
@@ -20,3 +21,40 @@ jobs:
 
       - name: Build binaries
         run: bash tool/build_linux.sh x64
+
+      - name: Upload binary
+        if: github.event_name == 'workflow_dispatch'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          overwrite: true
+          file: libpowersync_x64.so
+          asset_name: libpowersync_x64.so
+          tag: ${{ github.ref_name }}
+
+  build_aarch64:
+    name: Building Linux aarch64
+    runs-on: ubuntu-arm64
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Install Rust Nightly
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly-2024-05-18
+          components: rust-src
+
+      - name: Build binaries
+        run: bash tool/build_linux.sh aarch64
+
+      - name: Upload binary
+        if: github.event_name == 'workflow_dispatch'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          overwrite: true
+          file: libpowersync_aarch64.so
+          asset_name: libpowersync_aarch64.so
+          tag: ${{ github.ref_name }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,12 +24,10 @@ jobs:
 
       - name: Upload binary
         if: github.event_name == 'workflow_dispatch'
-        uses: svenstaro/upload-release-action@v2
+        uses: ./.github/actions/upload
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          overwrite: true
-          file: libpowersync_x64.so
-          asset_name: libpowersync_x64.so
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          file-name: libpowersync_x64.so
           tag: ${{ github.ref_name }}
 
   build_aarch64:
@@ -51,10 +49,8 @@ jobs:
 
       - name: Upload binary
         if: github.event_name == 'workflow_dispatch'
-        uses: svenstaro/upload-release-action@v2
+        uses: ./.github/actions/upload
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          overwrite: true
-          file: libpowersync_aarch64.so
-          asset_name: libpowersync_aarch64.so
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          file-name: libpowersync_aarch64.so
           tag: ${{ github.ref_name }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,5 +20,5 @@ jobs:
         uses: ./.github/actions/upload
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          file-name: powersync_x64.so
+          file-name: powersync_x64.dll
           tag: ${{ github.ref_name }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,3 +14,11 @@ jobs:
 
       - name: Build binary
         run: bash tool/build_windows.sh x64
+
+      - name: Upload binary
+        if: github.event_name == 'workflow_dispatch'
+        uses: ./.github/actions/upload
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          file-name: powersync_x64.so
+          tag: ${{ github.ref_name }}

--- a/tool/build_linux.sh
+++ b/tool/build_linux.sh
@@ -3,7 +3,6 @@ if [ "$1" = "x64" ]; then
   cargo build -p powersync_loadable --release
   mv "target/release/libpowersync.so" "libpowersync_x64.so"
 else
-  #Note: aarch64-unknown-linux-gnu has not been tested.
   rustup target add aarch64-unknown-linux-gnu
   cargo build -p powersync_loadable --release
   mv "target/release/libpowersync.so" "libpowersync_aarch64.so"


### PR DESCRIPTION
## Work done

- Enable building linux arm64 builds
- Enable manually building linux and windows based on latest tag (This is so that we don't have to create a new release for the arm builds)