### PR TITLE
Remove checkout twice on upload

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Build binaries
         run: bash tool/build_linux.sh x64
 
-      - uses: actions/checkout@v3
       - name: Upload binary
         if: github.event_name == 'workflow_dispatch'
         uses: ./.github/actions/upload
@@ -48,7 +47,6 @@ jobs:
       - name: Build binaries
         run: bash tool/build_linux.sh aarch64
 
-      - uses: actions/checkout@v3
       - name: Upload binary
         if: github.event_name == 'workflow_dispatch'
         uses: ./.github/actions/upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,6 @@ jobs:
       - name: Build binaries
         run: bash tool/build_linux.sh x64
 
-      - uses: actions/checkout@v3
       - name: Upload binary
         uses: ./.github/actions/upload
         with:
@@ -155,7 +154,6 @@ jobs:
       - name: Build binaries
         run: bash tool/build_linux.sh aarch64
 
-      - uses: actions/checkout@v3
       - name: Upload binary
         uses: ./.github/actions/upload
         with:
@@ -175,7 +173,6 @@ jobs:
       - name: Build binary
         run: bash tool/build_windows.sh x64
 
-      - uses: actions/checkout@v3
       - name: Upload binary
         uses: ./.github/actions/upload
         with:
@@ -195,7 +192,6 @@ jobs:
       - name: Build binary
         run: bash tool/build_macos.sh aarch64
 
-      - uses: actions/checkout@v3
       - name: Upload binary
         uses: ./.github/actions/upload
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Build binary
         run: bash tool/build_windows.sh x64
 
-      - uses: actions/checkout@v3
       - name: Upload binary
         if: github.event_name == 'workflow_dispatch'
         uses: ./.github/actions/upload


### PR DESCRIPTION
## Work done

Fixes actions not running because it checkouts the repository again removing the built binary file (https://github.com/powersync-ja/powersync-sqlite-core/actions/runs/9942707097/job/27464810046).

- Remove double checkout on uploading a binary