### PR TITLE
Custom prefab build for Android

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -52,3 +52,26 @@ rustflags = [
     "-C", "link-arg=-mmacosx-version-min=10.13",
 ]
 
+
+# For Android, it is important to set the soname.
+# Otherwise, the linker hardcodes the path in the lib,
+# which breaks loading.
+[target.aarch64-linux-android]
+rustflags = [
+    "-C", "link-arg=-Wl,-soname,libpowersync.so",
+]
+
+[target.armv7-linux-androideabi]
+rustflags = [
+    "-C", "link-arg=-Wl,-soname,libpowersync.so",
+]
+
+[target.x86_64-linux-android]
+rustflags = [
+    "-C", "link-arg=-Wl,-soname,libpowersync.so",
+]
+
+[target.i686-linux-android]
+rustflags = [
+    "-C", "link-arg=-Wl,-soname,libpowersync.so",
+]

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,10 +17,6 @@ jobs:
           distribution: "temurin"
           java-version: "17"
 
-      - uses: nttld/setup-ndk@v1
-        with:
-          ndk-version: r26
-
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,7 +1,5 @@
 on:
   push:
-    tags:
-      - "*"
 name: "android"
 jobs:
   build:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,7 +1,5 @@
 on:
   push:
-    tags:
-      - "*"
 name: "ios"
 jobs:
   build:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,7 +1,5 @@
 on:
   push:
-    tags:
-      - "*"
   workflow_dispatch:
 name: "linux"
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,6 @@ jobs:
           distribution: "temurin"
           java-version: "17"
 
-      - uses: nttld/setup-ndk@v1
-        with:
-          ndk-version: r26
-
       - name: Setup
         run: |
           rustup toolchain install nightly-2024-05-18-x86_64-unknown-linux-gnu

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+name: "linux"
+jobs:
+  build_wasm:
+    name: Basic WASM build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Install Rust Nightly
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly-2024-05-18
+          components: rust-src
+
+      - name: Build WASM bytecode
+        run: RUSTFLAGS="--emit=llvm-bc -C linker=/bin/true" cargo build -p powersync_loadable --profile wasm --no-default-features --features "powersync_core/static powersync_core/omit_load_extension sqlite_nostd/static sqlite_nostd/omit_load_extension" -Z build-std=panic_abort,core,alloc --target wasm32-unknown-emscripten

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,7 +1,5 @@
 on:
   push:
-    tags:
-      - "*"
 name: "windows"
 jobs:
   build_windows:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "powersync_core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytes",
  "num-derive",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cc",
  "powersync_core",
@@ -331,7 +331,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "sqlite3"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ inherits = "release"
 lto = false
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,8 +5,9 @@ Bump the version number in these places:
 1. Cargo.toml
 2. powersync-sqlite-core.podspec.
 3. android/build.gradle.kts
-4. build-pod.sh - CFBundleVersion and CFBundleShortVersionString.
-5. `cargo build` to update Cargo.lock
+4. android/src/prefab/prefab.json
+5. build-pod.sh - CFBundleVersion and CFBundleShortVersionString.
+6. `cargo build` to update Cargo.lock
 
 Create a tag:
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -63,7 +63,7 @@ val prefabAar = tasks.register<Zip>("prefabAar") {
         }
     }
 
-    archiveFileName.set("build/outputs/powersync-sqlite-core.aar")
+    archiveFileName.set("build/outputs/aar/powersync-sqlite-core.aar")
     destinationDirectory.set(file("./"))
 }
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "co.powersync"
-version = "0.2.0"
+version = "0.2.1"
 description = "PowerSync Core SQLite Extension"
 
 repositories {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -157,3 +157,7 @@ signing {
 tasks.withType<AbstractPublishToMaven>() {
     dependsOn(prefabAar)
 }
+
+tasks.named("build") {
+    dependsOn(prefabAar)
+}

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/src/AndroidManifest.xml
+++ b/android/src/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="co.powersync.sqlitecore" >
+
+    <uses-sdk android:minSdkVersion="21" />
+
+</manifest>

--- a/android/src/prefab/modules/powersync/include/powersync.h
+++ b/android/src/prefab/modules/powersync/include/powersync.h
@@ -1,0 +1,9 @@
+#ifndef POWERSYNC_H
+#define POWERSYNC_H
+
+#include "sqlite3.h"
+
+extern "C" int sqlite3_powersync_init(sqlite3 *db, char **pzErrMsg,
+                           const sqlite3_api_routines *pApi);
+
+#endif

--- a/android/src/prefab/modules/powersync/libs/android.arm64-v8a/abi.json
+++ b/android/src/prefab/modules/powersync/libs/android.arm64-v8a/abi.json
@@ -1,0 +1,7 @@
+{
+  "abi": "arm64-v8a",
+  "api": 21,
+  "ndk": 25,
+  "stl": "none",
+  "static": false
+}

--- a/android/src/prefab/modules/powersync/libs/android.armeabi-v7a/abi.json
+++ b/android/src/prefab/modules/powersync/libs/android.armeabi-v7a/abi.json
@@ -1,0 +1,7 @@
+{
+  "abi": "armeabi-v7a",
+  "api": 21,
+  "ndk": 25,
+  "stl": "none",
+  "static": false
+}

--- a/android/src/prefab/modules/powersync/libs/android.x86/abi.json
+++ b/android/src/prefab/modules/powersync/libs/android.x86/abi.json
@@ -1,0 +1,7 @@
+{
+  "abi": "x86",
+  "api": 21,
+  "ndk": 25,
+  "stl": "none",
+  "static": false
+}

--- a/android/src/prefab/modules/powersync/libs/android.x86_64/abi.json
+++ b/android/src/prefab/modules/powersync/libs/android.x86_64/abi.json
@@ -1,0 +1,7 @@
+{
+  "abi": "x86_64",
+  "api": 21,
+  "ndk": 25,
+  "stl": "none",
+  "static": false
+}

--- a/android/src/prefab/modules/powersync/module.json
+++ b/android/src/prefab/modules/powersync/module.json
@@ -1,0 +1,4 @@
+{
+  "export_libraries": [],
+  "android": {}
+}

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -1,0 +1,6 @@
+{
+  "name": "powersync_sqlite_core",
+  "schema_version": 2,
+  "dependencies": [],
+  "version": "0.2.0"
+}

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/build-pod.sh
+++ b/build-pod.sh
@@ -28,9 +28,9 @@ function createXcframework() {
   <key>MinimumOSVersion</key>
   <string>11.0</string>
   <key>CFBundleVersion</key>
-  <string>0.2.0</string>
+  <string>0.2.1</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.2.0</string>
+  <string>0.2.1</string>
 </dict>
 </plist>
 EOF

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.2.0'
+  s.version          = '0.2.1'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.


### PR DESCRIPTION
When we just want to bundle the `libpowersync.so` files into the final .apk, the `jniLibs` approach works file. However, if we want to use the libs from another native Android library, such as with `react-native-quick-sqlite`, that approach is insufficient. Instead, we need [Prefab](https://developer.android.com/build/native-dependencies) for that.

The native Android tooling only supports building Prefab libraries using CMake or the NDK. Lucky for us, the Prefab format is very simple, and we can create a custom .aar file with the Prefab structure. We now completely avoid the android gradle plugin for generating the aar file.

The final .aar file will contain the following files:

```
AndroidManifest.xml
jni/arm64-v8a/libpowersync.so
jni/armeabi-v7a/libpowersync.so
jni/x86_64/libpowersync.so
jni/x86/libpowersync.so
META-INF/com/android/build/gradle/aar-metadata.properties
prefab/modules/powersync/include/powersync.h
prefab/modules/powersync/libs/android.arm64-v8a/abi.json
prefab/modules/powersync/libs/android.arm64-v8a/libpowersync.so
prefab/modules/powersync/libs/android.armeabi-v7a/abi.json
prefab/modules/powersync/libs/android.armeabi-v7a/libpowersync.so
prefab/modules/powersync/libs/android.x86_64/abi.json
prefab/modules/powersync/libs/android.x86_64/libpowersync.so
prefab/modules/powersync/libs/android.x86/abi.json
prefab/modules/powersync/libs/android.x86/libpowersync.so
prefab/modules/powersync/module.json
prefab/prefab.json
```

Usage in the consuming project:

```gradle
// build.gradle
dependencies {
    implementation 'co.powersync:powersync-sqlite-core:0.2.0'
}
```

```
# CMakeLists.txt
find_package(powersync_sqlite_core REQUIRED CONFIG)

target_link_libraries(
  ${PACKAGE_NAME}
  # ...
  powersync_sqlite_core::powersync
)
```

The `prefab` folder is new, the rest were there before.

Note: prefab is _only_ relevant when linking to this library via native code on Android. FFI or loading the extension via SQLite APIs does not need this.