### PR TITLE
Checksum Caching

### DIFF
--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -97,6 +97,7 @@ INSERT INTO ps_oplog(bucket, op_id, op, key, row_type, row_id, data, hash, super
 
     let mut last_op: Option<i64> = None;
     let mut add_checksum: i32 = 0;
+    let mut op_checksum: i32 = 0;
 
     while iterate_statement.step()? == ResultCode::ROW {
         let op_id = iterate_statement.column_int64(0)?;
@@ -126,6 +127,7 @@ INSERT INTO ps_oplog(bucket, op_id, op, key, row_type, row_id, data, hash, super
                 let superseded_op = supersede_statement.column_int64(0)?;
                 let supersede_checksum = supersede_statement.column_int(1)?;
                 add_checksum = add_checksum.wrapping_add(supersede_checksum);
+                op_checksum = op_checksum.wrapping_sub(supersede_checksum);
 
                 if superseded_op <= last_applied_op {
                     // Superseded an operation previously applied - we cannot skip removes
@@ -172,6 +174,8 @@ INSERT INTO ps_oplog(bucket, op_id, op, key, row_type, row_id, data, hash, super
 
             insert_statement.bind_int(8, checksum)?;
             insert_statement.exec()?;
+
+            op_checksum = op_checksum.wrapping_add(checksum);
         } else if op == "MOVE" {
             add_checksum = add_checksum.wrapping_add(checksum);
         } else if op == "CLEAR" {
@@ -185,7 +189,7 @@ INSERT INTO ps_oplog(bucket, op_id, op, key, row_type, row_id, data, hash, super
             // We also replace the checksum with the checksum of the CLEAR op.
             // language=SQLite
             let clear_statement2 = db.prepare_v2(
-                "UPDATE ps_buckets SET last_applied_op = 0, add_checksum = ?1 WHERE name = ?2",
+                "UPDATE ps_buckets SET last_applied_op = 0, add_checksum = ?1, op_checksum = 0 WHERE name = ?2",
             )?;
             clear_statement2.bind_text(2, bucket, sqlite::Destructor::STATIC)?;
             clear_statement2.bind_int(1, checksum)?;
@@ -193,6 +197,7 @@ INSERT INTO ps_oplog(bucket, op_id, op, key, row_type, row_id, data, hash, super
 
             add_checksum = 0;
             last_applied_op = 0;
+            op_checksum = 0;
         }
     }
 
@@ -201,12 +206,14 @@ INSERT INTO ps_oplog(bucket, op_id, op, key, row_type, row_id, data, hash, super
         let statement = db.prepare_v2(
             "UPDATE ps_buckets
                 SET last_op = ?2,
-                    add_checksum = add_checksum + ?3
+                    add_checksum = (add_checksum + ?3) & 0xffffffff,
+                    op_checksum = (op_checksum + ?4) & 0xffffffff
             WHERE name = ?1",
         )?;
         statement.bind_text(1, bucket, sqlite::Destructor::STATIC)?;
         statement.bind_int64(2, *last_op)?;
         statement.bind_int(3, add_checksum)?;
+        statement.bind_int(4, op_checksum)?;
 
         statement.exec()?;
     }
@@ -216,17 +223,27 @@ INSERT INTO ps_oplog(bucket, op_id, op, key, row_type, row_id, data, hash, super
 
 pub fn clear_remove_ops(db: *mut sqlite::sqlite3, _data: &str) -> Result<(), SQLiteError> {
     // language=SQLite
-    let statement =
-        db.prepare_v2("SELECT name, last_applied_op FROM ps_buckets WHERE pending_delete = 0")?;
+    let statement = db.prepare_v2(
+        "
+SELECT
+    name,
+    last_applied_op,
+    (SELECT IFNULL(SUM(oplog.hash), 0)
+    FROM ps_oplog oplog
+    WHERE oplog.bucket = ps_buckets.name
+      AND oplog.op_id <= ps_buckets.last_applied_op
+      AND (oplog.superseded = 1 OR oplog.op != 3)
+    ) as checksum
+FROM ps_buckets
+WHERE ps_buckets.pending_delete = 0",
+    )?;
 
     // language=SQLite
     let update_statement = db.prepare_v2(
-        "UPDATE ps_buckets
-           SET add_checksum = add_checksum + (SELECT IFNULL(SUM(hash), 0)
-                                              FROM ps_oplog AS oplog
-                                              WHERE (superseded = 1 OR op != 3)
-                                                AND oplog.bucket = ?1
-                                                AND oplog.op_id <= ?2)
+        "
+        UPDATE ps_buckets
+           SET add_checksum = (add_checksum + ?2) & 0xffffffff,
+               op_checksum = (op_checksum - ?2) & 0xffffffff
            WHERE ps_buckets.name = ?1",
     )?;
 
@@ -243,9 +260,10 @@ pub fn clear_remove_ops(db: *mut sqlite::sqlite3, _data: &str) -> Result<(), SQL
         // Note: Each iteration here may be run in a separate transaction.
         let name = statement.column_text(0)?;
         let last_applied_op = statement.column_int64(1)?;
+        let checksum = statement.column_int(2)?;
 
         update_statement.bind_text(1, name, sqlite::Destructor::STATIC)?;
-        update_statement.bind_int64(2, last_applied_op)?;
+        update_statement.bind_int(2, checksum)?;
 
         update_statement.exec()?;
 

--- a/crates/core/src/view_admin.rs
+++ b/crates/core/src/view_admin.rs
@@ -131,7 +131,7 @@ CREATE TABLE IF NOT EXISTS ps_migration(id INTEGER PRIMARY KEY, down_migrations 
         return Err(SQLiteError::from(ResultCode::ABORT));
     }
 
-    const CODE_VERSION: i32 = 3;
+    const CODE_VERSION: i32 = 4;
 
     let mut current_version = current_version_stmt.column_int(0)?;
 
@@ -245,6 +245,19 @@ CREATE TABLE ps_kv(key TEXT PRIMARY KEY NOT NULL, value BLOB);
 INSERT INTO ps_kv(key, value) values('client_id', uuid());
 
 INSERT INTO ps_migration(id, down_migrations) VALUES(3, json_array(json_object('sql', 'DELETE FROM ps_migration WHERE id >= 3'), json_object('sql', 'DROP TABLE ps_kv')));
+    ").into_db_result(local_db)?;
+    }
+
+    if current_version < 4 {
+        // language=SQLite
+        local_db.exec_safe("\
+ALTER TABLE ps_buckets ADD COLUMN op_checksum INTEGER NOT NULL DEFAULT 0;
+
+UPDATE ps_buckets SET op_checksum = (
+  SELECT IFNULL(SUM(ps_oplog.hash), 0) & 0xffffffff FROM ps_oplog WHERE ps_oplog.bucket = ps_buckets.name
+);
+
+INSERT INTO ps_migration(id, down_migrations) VALUES(4, json_array(json_object('sql', 'DELETE FROM ps_migration WHERE id >= 4'), json_object('sql', 'ALTER TABLE ps_buckets DROP COLUMN op_checksum')));
     ").into_db_result(local_db)?;
     }
 

--- a/crates/core/src/view_admin.rs
+++ b/crates/core/src/view_admin.rs
@@ -252,7 +252,7 @@ INSERT INTO ps_migration(id, down_migrations) VALUES(3, json_array(json_object('
         // language=SQLite
         local_db.exec_safe("\
 ALTER TABLE ps_buckets ADD COLUMN op_checksum INTEGER NOT NULL DEFAULT 0;
-ALTER TABLE ps_buckets ADD COLUMN pending_compact INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE ps_buckets ADD COLUMN remove_operations INTEGER NOT NULL DEFAULT 0;
 
 UPDATE ps_buckets SET op_checksum = (
   SELECT IFNULL(SUM(ps_oplog.hash), 0) & 0xffffffff FROM ps_oplog WHERE ps_oplog.bucket = ps_buckets.name
@@ -263,7 +263,7 @@ INSERT INTO ps_migration(id, down_migrations)
     json_array(
       json_object('sql', 'DELETE FROM ps_migration WHERE id >= 4'),
       json_object('sql', 'ALTER TABLE ps_buckets DROP COLUMN op_checksum'),
-      json_object('sql', 'ALTER TABLE ps_buckets DROP COLUMN pending_compact')
+      json_object('sql', 'ALTER TABLE ps_buckets DROP COLUMN remove_operations')
     ));
     ").into_db_result(local_db)?;
     }

--- a/crates/core/src/view_admin.rs
+++ b/crates/core/src/view_admin.rs
@@ -252,12 +252,19 @@ INSERT INTO ps_migration(id, down_migrations) VALUES(3, json_array(json_object('
         // language=SQLite
         local_db.exec_safe("\
 ALTER TABLE ps_buckets ADD COLUMN op_checksum INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE ps_buckets ADD COLUMN pending_compact INTEGER NOT NULL DEFAULT 0;
 
 UPDATE ps_buckets SET op_checksum = (
   SELECT IFNULL(SUM(ps_oplog.hash), 0) & 0xffffffff FROM ps_oplog WHERE ps_oplog.bucket = ps_buckets.name
 );
 
-INSERT INTO ps_migration(id, down_migrations) VALUES(4, json_array(json_object('sql', 'DELETE FROM ps_migration WHERE id >= 4'), json_object('sql', 'ALTER TABLE ps_buckets DROP COLUMN op_checksum')));
+INSERT INTO ps_migration(id, down_migrations)
+  VALUES(4,
+    json_array(
+      json_object('sql', 'DELETE FROM ps_migration WHERE id >= 4'),
+      json_object('sql', 'ALTER TABLE ps_buckets DROP COLUMN op_checksum'),
+      json_object('sql', 'ALTER TABLE ps_buckets DROP COLUMN pending_compact')
+    ));
     ").into_db_result(local_db)?;
     }
 


### PR DESCRIPTION
Cache checksums to improve performance when syncing 100k+ rows.

## Benchmarks

Flutter app, Linux desktop.

Start with 500k PUT operations, then time the latency of syncing 1 PUT or REMOVE operation.

Latency is timed from the client receiving the new checkpoint, to the changes being fully applied locally.

Before: ~860ms
After: ~3ms
After, REMOVE operation: ~300ms

REMOVE operations are still expensive due to the compact performed afterwards. The compact can be performed only if there are a high number of REMOVE operations, which will amortize the cost (added as a new option to the `clear_remove_ops` operation).