### PR TITLE
Build fixes and improvements

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,24 +1,35 @@
-# On Linux, if we don't link to gcc_eh, we get can get this error when loading the loadable extension:
-# undefined symbol: _Unwind_Resume
-# This adds around 29KB to the loadable extension.
-# It may also be an option to just define _Unwind_Resume, but it causes crashes on errors on e.g. iOS, so rather avoid it.
+
+# Previously we added this to rustflags for all linux builds:
+#   "-C", "link-arg=-lgcc_eh"
+# It was to fix this error when loading the loadable extension:
+#   undefined symbol: _Unwind_Resume
+# Now, we instead build using:
+#   -Z build-std=panic_abort,core,alloc
+# This fixes the same issue. We still keep -lgcc_eh,
+# to support manual builds without -Z build-std.
+
+# Without -Z build-std, with -lgcc_eh:
+#   241KB, loading works
+# Without -Z build-std, without -lgcc_eh:
+#   207KB, undefined symbol: _Unwind_Resume
+# With -Z build-std, without -lgcc_eh:
+#   173K, loading works
+# With -Z build-std, with -lgcc_eh:
+#   173K, loading works
+# Conclusion: -lgcc_eh has no effect when using -Z build-std.
 
 [target.x86_64-unknown-linux-gnu]
 rustflags = [
     "-C", "link-arg=-lgcc_eh",
 ]
 
-[target.i686-linux-unknown-linux-gnu]
-rustflags = [
-    "-C", "link-arg=-lgcc_eh",
-]
-
-[target.aarch64-linux-unknown-linux-gnu]
+[target.i686-unknown-linux-gnu]
 rustflags = [
     "-C", "link-arg=-lgcc_eh",
 ]
 
 [target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
 rustflags = [
     "-C", "link-arg=-lgcc_eh",
 ]

--- a/.github/actions/upload/action.yml
+++ b/.github/actions/upload/action.yml
@@ -15,10 +15,9 @@ runs:
   using: "composite"
   steps:
     - name: Upload binary
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ inputs.repo-token }}
-        overwrite: true
-        file: ${{ inputs.file-name }}
-        asset_name: ${{ inputs.file-name }}
-        tag: ${{ inputs.tag }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      run: |
+        gh release upload "${{ inputs.tag }}" "${{ inputs.file-name }}"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,5 @@
 on:
   push:
-  workflow_dispatch:
 name: "linux"
 jobs:
   build_x86_64:
@@ -20,14 +19,6 @@ jobs:
       - name: Build binaries
         run: ./tool/build_linux.sh x64
 
-      - name: Upload binary
-        if: github.event_name == 'workflow_dispatch'
-        uses: ./.github/actions/upload
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          file-name: libpowersync_x64.so
-          tag: ${{ github.ref_name }}
-
   build_aarch64:
     name: Building Linux aarch64
     runs-on: ubuntu-arm64
@@ -44,11 +35,3 @@ jobs:
 
       - name: Build binaries
         run: ./tool/build_linux.sh aarch64
-
-      - name: Upload binary
-        if: github.event_name == 'workflow_dispatch'
-        uses: ./.github/actions/upload
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          file-name: libpowersync_aarch64.so
-          tag: ${{ github.ref_name }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
           components: rust-src
 
       - name: Build binaries
-        run: bash tool/build_linux.sh x64
+        run: ./tool/build_linux.sh x64
 
       - name: Upload binary
         if: github.event_name == 'workflow_dispatch'
@@ -43,7 +43,7 @@ jobs:
           components: rust-src
 
       - name: Build binaries
-        run: bash tool/build_linux.sh aarch64
+        run: ./tool/build_linux.sh aarch64
 
       - name: Upload binary
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,8 +11,13 @@ jobs:
         with:
           submodules: true
 
+      - name: Setup
+        run: |
+          rustup toolchain install nightly-2024-05-18-aarch64-apple-darwin
+          rustup component add rust-src --toolchain nightly-2024-05-18-aarch64-apple-darwin
+
       - name: Build binary
-        run: bash tool/build_macos.sh aarch64
+        run: ./tool/build_macos.sh aarch64
 
       - name: Upload binary
         if: github.event_name == 'workflow_dispatch'
@@ -30,8 +35,13 @@ jobs:
         with:
           submodules: true
 
+      - name: Setup
+        run: |
+          rustup toolchain install nightly-2024-05-18-x86_64-apple-darwin
+          rustup component add rust-src --toolchain nightly-2024-05-18-x86_64-apple-darwin
+
       - name: Build binary
-        run: bash tool/build_macos.sh x64
+        run: ./tool/build_macos.sh x64
 
       - name: Upload binary
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,10 +11,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup
-        run: |
-          rustup toolchain install nightly-2024-05-18-aarch64-apple-darwin
-          rustup component add rust-src --toolchain nightly-2024-05-18-aarch64-apple-darwin
+      - name: Install Rust Nightly
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly-2024-05-18
+          components: rust-src
 
       - name: Build binary
         run: ./tool/build_macos.sh aarch64
@@ -35,10 +36,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup
-        run: |
-          rustup toolchain install nightly-2024-05-18-x86_64-apple-darwin
-          rustup component add rust-src --toolchain nightly-2024-05-18-x86_64-apple-darwin
+      - name: Install Rust Nightly
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly-2024-05-18
+          components: rust-src
 
       - name: Build binary
         run: ./tool/build_macos.sh x64

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,5 @@
 on:
   push:
-  workflow_dispatch:
 name: "macos"
 jobs:
   build_macOS_aarch64:
@@ -20,14 +19,6 @@ jobs:
       - name: Build binary
         run: ./tool/build_macos.sh aarch64
 
-      - name: Upload binary
-        if: github.event_name == 'workflow_dispatch'
-        uses: ./.github/actions/upload
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          file-name: libpowersync_aarch64.dylib
-          tag: ${{ github.ref_name }}
-
   build_macOS_x64:
     name: Building macOS x64
     runs-on: macos-12
@@ -44,11 +35,3 @@ jobs:
 
       - name: Build binary
         run: ./tool/build_macos.sh x64
-
-      - name: Upload binary
-        if: github.event_name == 'workflow_dispatch'
-        uses: ./.github/actions/upload
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          file-name: libpowersync_x64.dylib
-          tag: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
           components: rust-src
 
       - name: Build binary
-        run: ./tool/build_windows.sh x64
+        run: bash tool/build_windows.sh x64
 
       - name: Upload binary
         uses: ./.github/actions/upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,12 @@
 name: release
 on:
   workflow_dispatch:
-  push:
+    inputs:
+      publish:
+        type: boolean
+        required: false
+        default: false
+        description: Set to true to publish artifacts to external targets such as Maven Central
 jobs:
   draft_release:
     if: github.event_name == 'workflow_dispatch'
@@ -57,6 +62,7 @@ jobs:
           cargo install cargo-ndk
 
       - name: Publish for Android
+        if: ${{ inputs.publish }}
         run: |
           cd android
           ./gradlew publish
@@ -123,7 +129,7 @@ jobs:
           components: rust-src
 
       - name: Build binaries
-        run: bash tool/build_linux.sh x64
+        run: ./tool/build_linux.sh x64
 
       - name: Upload binary
         uses: ./.github/actions/upload
@@ -135,7 +141,7 @@ jobs:
   publish_linux_aarch64:
     name: Publish Linux aarch64
     needs: [draft_release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64
     steps:
       - uses: actions/checkout@v3
         with:
@@ -148,7 +154,7 @@ jobs:
           components: rust-src
 
       - name: Build binaries
-        run: bash tool/build_linux.sh aarch64
+        run: ./tool/build_linux.sh aarch64
 
       - name: Upload binary
         uses: ./.github/actions/upload
@@ -166,8 +172,14 @@ jobs:
         with:
           submodules: true
 
+      - name: Install Rust Nightly
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly-2024-05-18
+          components: rust-src
+
       - name: Build binary
-        run: bash tool/build_windows.sh x64
+        run: ./tool/build_windows.sh x64
 
       - name: Upload binary
         uses: ./.github/actions/upload
@@ -185,8 +197,14 @@ jobs:
         with:
           submodules: true
 
+      - name: Install Rust Nightly
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly-2024-05-18
+          components: rust-src
+
       - name: Build binary
-        run: bash tool/build_macos.sh aarch64
+        run: ./tool/build_macos.sh aarch64
 
       - name: Upload binary
         uses: ./.github/actions/upload
@@ -204,8 +222,14 @@ jobs:
         with:
           submodules: true
 
+      - name: Install Rust Nightly
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly-2024-05-18
+          components: rust-src
+
       - name: Build binary
-        run: bash tool/build_macos.sh x64
+        run: ./tool/build_macos.sh x64
 
       - name: Upload binary
         uses: ./.github/actions/upload

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build
         run: |
           # Need a debug build for the dart tests
-          cargo build -p powersync_loadable -Z build-std=panic_abort,core,alloc --release --target x86_64-unknown-linux-gnu
+          cargo build -p powersync_loadable
 
           cargo build -p powersync_loadable --release
           cargo build -p powersync_core --release --features static

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,13 @@ jobs:
       - name: Ubuntu setup
         if: matrix.os == 'ubuntu-24.04'
         run: |
-          sudo apt install libreadline-dev gcc-aarch64-linux-gnu
+          sudo apt install libreadline-dev
+
+      - name: Install Rust Nightly
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly-2024-05-18
+          components: rust-src
 
       - name: Build
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,12 +20,12 @@ jobs:
       - name: Ubuntu setup
         if: matrix.os == 'ubuntu-24.04'
         run: |
-          sudo apt install libreadline-dev
+          sudo apt install libreadline-dev gcc-aarch64-linux-gnu
 
       - name: Build
         run: |
           # Need a debug build for the dart tests
-          cargo build -p powersync_loadable
+          cargo build -p powersync_loadable -Z build-std=panic_abort,core,alloc --release --target x86_64-unknown-linux-gnu
 
           cargo build -p powersync_loadable --release
           cargo build -p powersync_core --release --features static

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,10 +10,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup
-        run: |
-          rustup toolchain install nightly-2024-05-18-x86_64-pc-windows-msvc
-          rustup component add rust-src --toolchain nightly-2024-05-18-x86_64-pc-windows-msvc
+      - name: Install Rust Nightly
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly-2024-05-18
+          components: rust-src
 
       - name: Build binary
         run: ./tool/build_windows.sh x64

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,11 +18,3 @@ jobs:
 
       - name: Build binary
         run: ./tool/build_windows.sh x64
-
-      - name: Upload binary
-        if: github.event_name == 'workflow_dispatch'
-        uses: ./.github/actions/upload
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          file-name: powersync_x64.dll
-          tag: ${{ github.ref_name }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,8 +10,13 @@ jobs:
         with:
           submodules: true
 
+      - name: Setup
+        run: |
+          rustup toolchain install nightly-2024-05-18-x86_64-pc-windows-msvc
+          rustup component add rust-src --toolchain nightly-2024-05-18-x86_64-pc-windows-msvc
+
       - name: Build binary
-        run: bash tool/build_windows.sh x64
+        run: ./tool/build_windows.sh x64
 
       - name: Upload binary
         if: github.event_name == 'workflow_dispatch'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,7 +21,7 @@ git push --tags
 Build:
 
 ```
-gh workflow run release --ref v1.2.3
+gh workflow run release --ref v1.2.3 -f publish=true
 ```
 
 The above does the following:

--- a/tool/build_linux.sh
+++ b/tool/build_linux.sh
@@ -1,9 +1,10 @@
+#!/bin/sh
+set -e
+
 if [ "$1" = "x64" ]; then
-  rustup target add target x86_64-unknown-linux-gnu
-  cargo build -p powersync_loadable --release
-  mv "target/release/libpowersync.so" "libpowersync_x64.so"
+  cargo build -p powersync_loadable -Z build-std=panic_abort,core,alloc --release --target x86_64-unknown-linux-gnu
+  mv "target/x86_64-unknown-linux-gnu/release/libpowersync.so" "libpowersync_x64.so"
 else
-  rustup target add aarch64-unknown-linux-gnu
-  cargo build -p powersync_loadable --release
-  mv "target/release/libpowersync.so" "libpowersync_aarch64.so"
+  cargo build -p powersync_loadable -Z build-std=panic_abort,core,alloc --release --target aarch64-unknown-linux-gnu
+  mv "target/aarch64-unknown-linux-gnu/release/libpowersync.so" "libpowersync_aarch64.so"
 fi

--- a/tool/build_macos.sh
+++ b/tool/build_macos.sh
@@ -1,10 +1,10 @@
+#!/bin/sh
+set -e
+
 if [ "$1" = "x64" ]; then
-  #Note: x86_64-apple-darwin has not been tested.
-  rustup target add target x86_64-apple-darwin
-  cargo build -p powersync_loadable --release
-  mv "target/release/libpowersync.dylib" "libpowersync_x64.dylib"
+  cargo build -Z build-std=panic_abort,core,alloc -p powersync_loadable --release --target x86_64-apple-darwin
+  mv "target/x86_64-apple-darwin/release/libpowersync.dylib" "libpowersync_x64.dylib"
 else
-  rustup target add aarch64-apple-darwin
-  cargo build -p powersync_loadable --release
-  mv "target/release/libpowersync.dylib" "libpowersync_aarch64.dylib"
+  cargo build -Z build-std=panic_abort,core,alloc -p powersync_loadable --release --target aarch64-apple-darwin
+  mv "target/aarch64-apple-darwin/release/libpowersync.dylib" "libpowersync_aarch64.dylib"
 fi

--- a/tool/build_windows.sh
+++ b/tool/build_windows.sh
@@ -1,10 +1,11 @@
+#!/bin/sh
+set -e
+
 if [ "$1" = "x64" ]; then
-  rustup target add x86_64-pc-windows-msvc
-  cargo build -p powersync_loadable --release
-  mv "target/release/powersync.dll" "powersync_x64.dll"
+  cargo build -Z build-std=panic_abort,core,alloc -p powersync_loadable --release --target x86_64-pc-windows-msvc
+  mv "target/x86_64-pc-windows-msvc/release/powersync.dll" "powersync_x64.dll"
 else
   #Note: aarch64-pc-windows-msvc has not been tested.
-  rustup target add aarch64-pc-windows-msvc
-  cargo build -p powersync_loadable --release
-  mv "target/release/powersync.dll" "powersync_aarch64.dll"
+  cargo build -Z build-std=panic_abort,core,alloc -p powersync_loadable --release --target aarch64-pc-windows-msvc
+  mv "target/aarch64-pc-windows-msvc/release/powersync.dll" "powersync_aarch64.dll"
 fi


### PR DESCRIPTION
This now adds explicit `-Z build-std` and `--target` specifiers to every release build.

The significant effects:
1. The `--target` ensures we actually build for the correct target. The current linux `libpowersync_aarch64.so` release is actually a x86_64 build.
2. build-std gives us a more optimized std-lib, and specifically removes any unwinding-related code. This reduces the output library size (241KB -> 173K for linux x86_64),
3. The above avoids `undefined symbol: _Unwind_Resume` or similar issues.

build-std also requires an explicit target. 

Additionally, this fixes some linux targets incorrectly specified in `.cargo/config.toml`.

This specifically affects linux, macos and windows builds - will have to test each of those again. Android, iOS and WASM already used build-std, and are not affected.

This also fixes some issues in the release process:
 * Only upload binaries in the release.yml workflow - the others were not used.
 * Use `gh release upload` for binary uploads. The previous method created both a draft release and another published release; this now only creates a single draft.

Sizes of artifacts after these changes:
![image](https://github.com/user-attachments/assets/3461d490-1cd8-4475-8869-b518a79bbed8)

Note: Manually rebuilt libpowersync_aarch64.so for release 0.2.0, 0.2.1 and 0.3.0 to fix the build issue in current releases.