### PR TITLE
fix: missing slash in file location

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Build iOS & macOS xcframework
         run: |
-          .tool/build_xcframework.sh
+          ./tool/build_xcframework.sh
 
       - name: Lint pod
         run: |


### PR DESCRIPTION
## Description
It should be `./tool/...` not `.tool/...` for the file location. This corrects the error.