### PR TITLE
Add --symlinks option for framework zip file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "powersync_core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "num-derive",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "cc",
  "powersync_core",
@@ -331,7 +331,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "sqlite3"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ inherits = "release"
 inherits = "wasm"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "co.powersync"
-version = "0.3.2"
+version = "0.3.3"
 description = "PowerSync Core SQLite Extension"
 
 repositories {

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.3.2"
+  "version": "0.3.3"
 }

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.3.2'
+  s.version          = '0.3.3'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -28,9 +28,9 @@ function createXcframework() {
   <key>MinimumOSVersion</key>
   <string>11.0</string>
   <key>CFBundleVersion</key>
-  <string>0.3.2</string>
+  <string>0.3.3</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.3.2</string>
+  <string>0.3.3</string>
 </dict>
 </plist>
 EOF

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -71,7 +71,7 @@ EOF
     -output "${BUILD_DIR}/powersync-sqlite-core.xcframework"
 
   cp -Rf "${BUILD_DIR}/powersync-sqlite-core.xcframework" "powersync-sqlite-core.xcframework"
-  zip -r powersync-sqlite-core.xcframework.zip powersync-sqlite-core.xcframework LICENSE README.md
+  zip -r --symlinks powersync-sqlite-core.xcframework.zip powersync-sqlite-core.xcframework LICENSE README.md
   rm -rf ${BUILD_DIR}
 }
 


### PR DESCRIPTION
## Description

When creating a zip file using the `zip` command on linux, it does not respect symlinks created in the directory. This caused the `pod spec lint` validation to fail when publishing the pod.
Adding the `--symlinks` flag ensures that symlinks are archived as-is, preventing them from being followed and included as regular files.

## Work done

- Updated the `build_xcframework.sh` script to include the --symlinks option when calling the zip command.
- Bump version to 0.3.3

Tested locally using the new zip file and the validation passes.