### PR TITLE
Revert ios framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "powersync_core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "bytes",
  "num-derive",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "cc",
  "powersync_core",
@@ -331,7 +331,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "sqlite3"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ inherits = "release"
 inherits = "wasm"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "co.powersync"
-version = "0.3.3"
+version = "0.3.4"
 description = "PowerSync Core SQLite Extension"
 
 repositories {

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.3.3"
+  "version": "0.3.4"
 }

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.3.3'
+  s.version          = '0.3.4'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -36,22 +36,16 @@ function createXcframework() {
 EOF
 )
   echo "===================== create ios device framework ====================="
-  mkdir -p "${BUILD_DIR}/ios-arm64/powersync-sqlite-core.framework/Versions/A/Resources"
-  echo "${plist}" > "${BUILD_DIR}/ios-arm64/powersync-sqlite-core.framework/Versions/A/Resources/Info.plist"
-  cp -f "./target/aarch64-apple-ios/release/libpowersync.dylib" "${BUILD_DIR}/ios-arm64/powersync-sqlite-core.framework/Versions/A/powersync-sqlite-core"
-  install_name_tool -id "@rpath/powersync-sqlite-core.framework/powersync-sqlite-core" "${BUILD_DIR}/ios-arm64/powersync-sqlite-core.framework/Versions/A/powersync-sqlite-core"
-  ln -s A "${BUILD_DIR}/ios-arm64/powersync-sqlite-core.framework/Versions/Current" #Symbolic link A to the current version directory
-  ln -s Versions/Current/powersync-sqlite-core "${BUILD_DIR}/ios-arm64/powersync-sqlite-core.framework/powersync-sqlite-core" #Symbolic link the binary
-  ln -s Versions/Current/Resources "${BUILD_DIR}/ios-arm64/powersync-sqlite-core.framework/Resources" #Symbolic link the resources
+  mkdir -p "${BUILD_DIR}/ios-arm64/powersync-sqlite-core.framework"
+  echo "${plist}" > "${BUILD_DIR}/ios-arm64/powersync-sqlite-core.framework/Info.plist"
+  cp -f "./target/aarch64-apple-ios/release/libpowersync.dylib" "${BUILD_DIR}/ios-arm64/powersync-sqlite-core.framework/powersync-sqlite-core"
+  install_name_tool -id "@rpath/powersync-sqlite-core.framework/powersync-sqlite-core" "${BUILD_DIR}/ios-arm64/powersync-sqlite-core.framework/powersync-sqlite-core"
 
   echo "===================== create ios simulator framework ====================="
-  mkdir -p "${BUILD_DIR}/ios-arm64_x86_64-simulator/powersync-sqlite-core.framework/Versions/A/Resources"
-  echo "${plist}" > "${BUILD_DIR}/ios-arm64_x86_64-simulator/powersync-sqlite-core.framework/Versions/A/Resources/Info.plist"
-  lipo ./target/aarch64-apple-ios-sim/release/libpowersync.dylib ./target/x86_64-apple-ios/release/libpowersync.dylib -create -output "${BUILD_DIR}/ios-arm64_x86_64-simulator/powersync-sqlite-core.framework/Versions/A/powersync-sqlite-core"
-  install_name_tool -id "@rpath/powersync-sqlite-core.framework/powersync-sqlite-core" "${BUILD_DIR}/ios-arm64_x86_64-simulator/powersync-sqlite-core.framework/Versions/A/powersync-sqlite-core"
-  ln -s A "${BUILD_DIR}/ios-arm64_x86_64-simulator/powersync-sqlite-core.framework/Versions/Current"
-  ln -s Versions/Current/powersync-sqlite-core "${BUILD_DIR}/ios-arm64_x86_64-simulator/powersync-sqlite-core.framework/powersync-sqlite-core"
-  ln -s Versions/Current/Resources "${BUILD_DIR}/ios-arm64_x86_64-simulator/powersync-sqlite-core.framework/Resources"
+  mkdir -p "${BUILD_DIR}/ios-arm64_x86_64-simulator/powersync-sqlite-core.framework"
+  echo "${plist}" > "${BUILD_DIR}/ios-arm64_x86_64-simulator/powersync-sqlite-core.framework/Info.plist"
+  lipo ./target/aarch64-apple-ios-sim/release/libpowersync.dylib ./target/x86_64-apple-ios/release/libpowersync.dylib -create -output "${BUILD_DIR}/ios-arm64_x86_64-simulator/powersync-sqlite-core.framework/powersync-sqlite-core"
+  install_name_tool -id "@rpath/powersync-sqlite-core.framework/powersync-sqlite-core" "${BUILD_DIR}/ios-arm64_x86_64-simulator/powersync-sqlite-core.framework/powersync-sqlite-core"
 
   echo "===================== create macos framework ====================="
   mkdir -p "${BUILD_DIR}/macos-arm64_x86_64/powersync-sqlite-core.framework/Versions/A/Resources"

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -28,9 +28,9 @@ function createXcframework() {
   <key>MinimumOSVersion</key>
   <string>11.0</string>
   <key>CFBundleVersion</key>
-  <string>0.3.3</string>
+  <string>0.3.4</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.3.3</string>
+  <string>0.3.4</string>
 </dict>
 </plist>
 EOF


### PR DESCRIPTION
## Description 

The framework bundle for powersync-sqlite-core.framework was causing a "Malformed Framework" error on macOS because it was missing the required symbolic links that are part of the standard framework structure. This was fixed in #41 however this change is not required for the iOS platforms and causes the distribution build (ipa/archive) to fail. 

Changes:

- Revert back to standard structure for iOS frameworks
- Bump versions

<img width="320" alt="Screenshot 2024-10-21 at 16 28 02" src="https://github.com/user-attachments/assets/b8207de1-0d20-4e40-958d-8c6d81304dc1">
