### PR TITLE
Add debug symbols for iOS and macOS builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "powersync_core"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "bytes",
  "num-derive",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "cc",
  "powersync_core",
@@ -331,7 +331,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "sqlite3"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "powersync_core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "bytes",
  "num-derive",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "cc",
  "powersync_core",
@@ -331,7 +331,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "sqlite3"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,11 @@ strip = true
 opt-level = "z"
 lto = true
 
+[profile.release_apple]
+inherits = "release"
+strip = false
+debug = true
+
 [profile.wasm]
 inherits = "release"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ inherits = "release"
 inherits = "wasm"
 
 [workspace.package]
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ inherits = "release"
 inherits = "wasm"
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "co.powersync"
-version = "0.3.8"
+version = "0.3.9"
 description = "PowerSync Core SQLite Extension"
 
 repositories {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "co.powersync"
-version = "0.3.7"
+version = "0.3.8"
 description = "PowerSync Core SQLite Extension"
 
 repositories {

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.3.7"
+  "version": "0.3.8"
 }

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.3.8"
+  "version": "0.3.9"
 }

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.3.7'
+  s.version          = '0.3.8'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.3.8'
+  s.version          = '0.3.9'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -28,9 +28,9 @@ function createXcframework() {
   <key>MinimumOSVersion</key>
   <string>11.0</string>
   <key>CFBundleVersion</key>
-  <string>0.3.8</string>
+  <string>0.3.9</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.3.8</string>
+  <string>0.3.9</string>
 </dict>
 </plist>
 EOF

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -28,9 +28,9 @@ function createXcframework() {
   <key>MinimumOSVersion</key>
   <string>11.0</string>
   <key>CFBundleVersion</key>
-  <string>0.3.7</string>
+  <string>0.3.8</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.3.7</string>
+  <string>0.3.8</string>
 </dict>
 </plist>
 EOF


### PR DESCRIPTION
There is now an error message in Xcode 16 for a missing dSYM folder and DWARF file.
```
The archive did not include a dSYM for the powersync-sqlite-core.framework with the 
UUIDs [7E9FE23E-F16F-35CB-830B-54AD4C79F057]. Ensure that the archive's dSYM 
folder includes a DWARF file for powersync-sqlite-core.framework with the expected UUIDs.
``` 