### PR TITLE
Increase column limit to 1999

### DIFF
--- a/crates/core/src/diff.rs
+++ b/crates/core/src/diff.rs
@@ -1,12 +1,11 @@
 extern crate alloc;
 
-
 use alloc::format;
 use alloc::string::{String, ToString};
 use core::ffi::c_int;
 use core::slice;
 
-use sqlite::{ResultCode};
+use sqlite::ResultCode;
 use sqlite_nostd as sqlite;
 use sqlite_nostd::{Connection, Context, Value};
 
@@ -26,7 +25,6 @@ fn powersync_diff_impl(
 }
 
 pub fn diff_objects(data_old: &str, data_new: &str) -> Result<String, SQLiteError> {
-
     let v_new: json::Value = json::from_str(data_new)?;
     let v_old: json::Value = json::from_str(data_old)?;
 
@@ -81,7 +79,6 @@ pub fn register(db: *mut sqlite::sqlite3) -> Result<(), ResultCode> {
     Ok(())
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -91,17 +88,53 @@ mod tests {
         assert_eq!(diff_objects("{}", "{}").unwrap(), "{}");
         assert_eq!(diff_objects(r#"{"a": null}"#, "{}").unwrap(), "{}");
         assert_eq!(diff_objects(r#"{}"#, r#"{"a": null}"#).unwrap(), "{}");
-        assert_eq!(diff_objects(r#"{"b": 1}"#, r#"{"a": null, "b": 1}"#).unwrap(), "{}");
-        assert_eq!(diff_objects(r#"{"b": 1}"#, r#"{"a": null, "b": 2}"#).unwrap(), r#"{"b":2}"#);
-        assert_eq!(diff_objects(r#"{"a": 0, "b": 1}"#, r#"{"a": null, "b": 2}"#).unwrap(), r#"{"a":null,"b":2}"#);
-        assert_eq!(diff_objects(r#"{"a": 1}"#, r#"{"a": null}"#).unwrap(), r#"{"a":null}"#);
-        assert_eq!(diff_objects(r#"{"a": 1}"#, r#"{}"#).unwrap(), r#"{"a":null}"#);
-        assert_eq!(diff_objects(r#"{"a": 1}"#, r#"{"a": 2}"#).unwrap(), r#"{"a":2}"#);
-        assert_eq!(diff_objects(r#"{"a": 1}"#, r#"{"a": "1"}"#).unwrap(), r#"{"a":"1"}"#);
-        assert_eq!(diff_objects(r#"{"a": 1}"#, r#"{"a": 1.0}"#).unwrap(), r#"{"a":1.0}"#);
-        assert_eq!(diff_objects(r#"{"a": 1.00}"#, r#"{"a": 1.0}"#).unwrap(), r#"{}"#);
-        assert_eq!(diff_objects(r#"{}"#, r#"{"a": 1.0}"#).unwrap(), r#"{"a":1.0}"#);
-        assert_eq!(diff_objects(r#"{}"#, r#"{"a": [1,2,3]}"#).unwrap(), r#"{"a":[1,2,3]}"#);
-        assert_eq!(diff_objects(r#"{"a": 1}"#, r#"{"a": [1,2,3]}"#).unwrap(), r#"{"a":[1,2,3]}"#);
+        assert_eq!(
+            diff_objects(r#"{"b": 1}"#, r#"{"a": null, "b": 1}"#).unwrap(),
+            "{}"
+        );
+        assert_eq!(
+            diff_objects(r#"{"b": 1}"#, r#"{"a": null, "b": 2}"#).unwrap(),
+            r#"{"b":2}"#
+        );
+        assert_eq!(
+            diff_objects(r#"{"a": 0, "b": 1}"#, r#"{"a": null, "b": 2}"#).unwrap(),
+            r#"{"a":null,"b":2}"#
+        );
+        assert_eq!(
+            diff_objects(r#"{"a": 1}"#, r#"{"a": null}"#).unwrap(),
+            r#"{"a":null}"#
+        );
+        assert_eq!(
+            diff_objects(r#"{"a": 1}"#, r#"{}"#).unwrap(),
+            r#"{"a":null}"#
+        );
+        assert_eq!(
+            diff_objects(r#"{"a": 1}"#, r#"{"a": 2}"#).unwrap(),
+            r#"{"a":2}"#
+        );
+        assert_eq!(
+            diff_objects(r#"{"a": 1}"#, r#"{"a": "1"}"#).unwrap(),
+            r#"{"a":"1"}"#
+        );
+        assert_eq!(
+            diff_objects(r#"{"a": 1}"#, r#"{"a": 1.0}"#).unwrap(),
+            r#"{"a":1.0}"#
+        );
+        assert_eq!(
+            diff_objects(r#"{"a": 1.00}"#, r#"{"a": 1.0}"#).unwrap(),
+            r#"{}"#
+        );
+        assert_eq!(
+            diff_objects(r#"{}"#, r#"{"a": 1.0}"#).unwrap(),
+            r#"{"a":1.0}"#
+        );
+        assert_eq!(
+            diff_objects(r#"{}"#, r#"{"a": [1,2,3]}"#).unwrap(),
+            r#"{"a":[1,2,3]}"#
+        );
+        assert_eq!(
+            diff_objects(r#"{"a": 1}"#, r#"{"a": [1,2,3]}"#).unwrap(),
+            r#"{"a":[1,2,3]}"#
+        );
     }
 }

--- a/crates/core/src/json_merge.rs
+++ b/crates/core/src/json_merge.rs
@@ -1,0 +1,57 @@
+extern crate alloc;
+
+use alloc::format;
+use alloc::string::{String, ToString};
+use core::ffi::c_int;
+use core::slice;
+
+use sqlite::ResultCode;
+use sqlite_nostd as sqlite;
+use sqlite_nostd::{Connection, Context, Value};
+
+use serde_json as json;
+
+use crate::create_sqlite_text_fn;
+use crate::error::SQLiteError;
+
+/// Given any number of JSON TEXT arguments, merge them into a single JSON object.
+///
+/// TODO: If we know these are all valid JSON objects, we could perhaps do string concatenation instead.
+fn powersync_json_merge_impl(
+    _ctx: *mut sqlite::context,
+    args: &[*mut sqlite::value],
+) -> Result<String, SQLiteError> {
+    let mut v_result = json::Value::Object(json::Map::new());
+    for arg in args {
+        let v: json::Value = json::from_str(arg.text())?;
+        if let json::Value::Object(map) = v {
+            for (key, value) in map {
+                v_result[key] = value;
+            }
+        } else {
+            return Err(SQLiteError::from(ResultCode::MISMATCH));
+        }
+    }
+    return Ok(v_result.to_string());
+}
+
+create_sqlite_text_fn!(
+    powersync_json_merge,
+    powersync_json_merge_impl,
+    "powersync_json_merge"
+);
+
+pub fn register(db: *mut sqlite::sqlite3) -> Result<(), ResultCode> {
+    db.create_function_v2(
+        "powersync_json_merge",
+        -1,
+        sqlite::UTF8 | sqlite::DETERMINISTIC,
+        None,
+        Some(powersync_json_merge),
+        None,
+        None,
+        None,
+    )?;
+
+    Ok(())
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -18,6 +18,7 @@ mod diff;
 mod error;
 mod ext;
 mod fix035;
+mod json_merge;
 mod kv;
 mod macros;
 mod migrations;
@@ -55,6 +56,7 @@ fn init_extension(db: *mut sqlite::sqlite3) -> Result<(), ResultCode> {
     crate::views::register(db)?;
     crate::uuid::register(db)?;
     crate::diff::register(db)?;
+    crate::json_merge::register(db)?;
     crate::view_admin::register(db)?;
     crate::checkpoint::register(db)?;
     crate::kv::register(db)?;

--- a/dart/test/crud_test.dart
+++ b/dart/test/crud_test.dart
@@ -1,0 +1,230 @@
+import 'dart:convert';
+
+import 'package:sqlite3/common.dart';
+import 'package:test/test.dart';
+
+import 'utils/native_test_utils.dart';
+
+void main() {
+  group('crud tests', () {
+    late CommonDatabase db;
+
+    setUp(() async {
+      db = openTestDatabase();
+    });
+
+    tearDown(() {
+      db.dispose();
+    });
+
+    test('powersync_diff - single value', () {
+      var r1 =
+          db.select('select powersync_diff(?, ?) as diff', ['{}', '{}']).first;
+      expect(r1['diff'], equals('{}'));
+
+      var r2 = db.select(
+          'select powersync_diff(?, ?) as diff', ['{}', '{"test":1}']).first;
+      expect(r2['diff'], equals('{"test":1}'));
+
+      var r3 = db.select('select powersync_diff(?, ?) as diff',
+          ['{"test":1}', '{"test":1}']).first;
+      expect(r3['diff'], equals('{}'));
+
+      var r4 = db.select(
+          'select powersync_diff(?, ?) as diff', ['{"test":1}', '{}']).first;
+      expect(r4['diff'], equals('{"test":null}'));
+
+      var r5 = db.select('select powersync_diff(?, ?) as diff',
+          ['{"test":1}', '{"test":null}']).first;
+      expect(r5['diff'], equals('{"test":null}'));
+
+      var r6 = db.select('select powersync_diff(?, ?) as diff',
+          ['{"test":1}', '{"test":2}']).first;
+      expect(r6['diff'], equals('{"test":2}'));
+    });
+
+    test('powersync_diff - multiple values', () {
+      var r1 = db.select('select powersync_diff(?, ?) as diff',
+          ['{"a":1,"b":"test"}', '{}']).first;
+      expect(r1['diff'], equals('{"a":null,"b":null}'));
+
+      var r2 = db.select('select powersync_diff(?, ?) as diff',
+          ['{}', '{"a":1,"b":"test"}']).first;
+      expect(r2['diff'], equals('{"a":1,"b":"test"}'));
+
+      var r3 = db.select('select powersync_diff(?, ?) as diff',
+          ['{"a":1,"b":"test"}', '{"a":1,"b":"test"}']).first;
+      expect(r3['diff'], equals('{}'));
+
+      var r4 = db.select('select powersync_diff(?, ?) as diff',
+          ['{"a":1}', '{"b":"test"}']).first;
+      expect(r4['diff'], equals('{"a":null,"b":"test"}'));
+
+      var r5 = db.select('select powersync_diff(?, ?) as diff',
+          ['{"a":1}', '{"a":1,"b":"test"}']).first;
+      expect(r5['diff'], equals('{"b":"test"}'));
+    });
+
+    var runCrudTest = (int numberOfColumns) {
+      var columns = [];
+      for (var i = 0; i < numberOfColumns; i++) {
+        columns.add({'name': 'column$i', 'type': 'TEXT'});
+      }
+      var tableSchema = {
+        'tables': [
+          {'name': 'items', 'columns': columns}
+        ]
+      };
+      db.select('select powersync_init()');
+
+      // 1. Test schema initialization
+      db.select(
+          'select powersync_replace_schema(?)', [jsonEncode(tableSchema)]);
+
+      var columnNames = columns.map((c) => c['name']).join(', ');
+      var columnValues = columns.map((c) => "'${c['name']}'").join(', ');
+
+      // 2. Test insert
+      db.select(
+          "insert into items(id, ${columnNames}) values('test_id', ${columnValues})");
+      var item = db.select('select * from items').first;
+      var expectedData =
+          Map.fromEntries(columns.map((c) => MapEntry(c['name'], c['name'])));
+
+      expect(item, equals({'id': 'test_id', ...expectedData}));
+      var crud = db.select('select * from ps_crud').first;
+      var crudData = jsonDecode(crud['data']);
+      expect(crud['tx_id'], equals(1));
+      expect(
+          crudData,
+          equals({
+            'op': 'PUT',
+            'type': 'items',
+            'id': 'test_id',
+            'data': expectedData
+          }));
+
+      // 3. Test update
+      db.select('update items set column0 = ?', ['new_value']);
+      var itemUpdated = db.select('select * from items').first;
+      expect(itemUpdated,
+          equals({'id': 'test_id', ...expectedData, 'column0': 'new_value'}));
+
+      var crudUpdated = db.select('select * from ps_crud where id = 2').first;
+      var crudDataUpdated = jsonDecode(crudUpdated['data']);
+      expect(crudUpdated['tx_id'], equals(2));
+      expect(
+          crudDataUpdated,
+          equals({
+            'op': 'PATCH',
+            'type': 'items',
+            'id': 'test_id',
+            'data': {'column0': 'new_value'}
+          }));
+
+      // 4. Test delete
+      db.select('delete from items');
+      var itemDeleted = db.select('select * from items').firstOrNull;
+      expect(itemDeleted, equals(null));
+
+      var crudDeleted = db.select('select * from ps_crud where id = 3').first;
+      var crudDataDeleted = jsonDecode(crudDeleted['data']);
+      expect(crudDeleted['tx_id'], equals(3));
+      expect(crudDataDeleted,
+          equals({'op': 'DELETE', 'type': 'items', 'id': 'test_id'}));
+    };
+
+    var runCrudTestLocalOnly = (int numberOfColumns) {
+      var columns = [];
+      for (var i = 0; i < numberOfColumns; i++) {
+        columns.add({'name': 'column$i', 'type': 'TEXT'});
+      }
+      var tableSchema = {
+        'tables': [
+          {'name': 'items', 'columns': columns, 'local_only': true}
+        ]
+      };
+      db.select('select powersync_init()');
+
+      // 1. Test schema initialization
+      db.select(
+          'select powersync_replace_schema(?)', [jsonEncode(tableSchema)]);
+
+      var columnNames = columns.map((c) => c['name']).join(', ');
+      var columnValues = columns.map((c) => "'${c['name']}'").join(', ');
+
+      // 2. Test insert
+      db.select(
+          "insert into items(id, ${columnNames}) values('test_id', ${columnValues})");
+      var item = db.select('select * from items').first;
+      var expectedData =
+          Map.fromEntries(columns.map((c) => MapEntry(c['name'], c['name'])));
+
+      expect(item, equals({'id': 'test_id', ...expectedData}));
+
+      // 3. Test update
+      db.select('update items set column0 = ?', ['new_value']);
+      var itemUpdated = db.select('select * from items').first;
+      expect(itemUpdated,
+          equals({'id': 'test_id', ...expectedData, 'column0': 'new_value'}));
+
+      // 4. Test delete
+      db.select('delete from items');
+      var itemDeleted = db.select('select * from items').firstOrNull;
+      expect(itemDeleted, equals(null));
+    };
+
+    var runCrudTestInsertOnly = (int numberOfColumns) {
+      var columns = [];
+      for (var i = 0; i < numberOfColumns; i++) {
+        columns.add({'name': 'column$i', 'type': 'TEXT'});
+      }
+      var tableSchema = {
+        'tables': [
+          {'name': 'items', 'columns': columns, 'insert_only': true}
+        ]
+      };
+      db.select('select powersync_init()');
+
+      // 1. Test schema initialization
+      db.select(
+          'select powersync_replace_schema(?)', [jsonEncode(tableSchema)]);
+
+      var columnNames = columns.map((c) => c['name']).join(', ');
+      var columnValues = columns.map((c) => "'${c['name']}'").join(', ');
+
+      // 2. Test insert
+      db.select(
+          "insert into items(id, ${columnNames}) values('test_id', ${columnValues})");
+      var item = db.select('select * from items').firstOrNull;
+      expect(item, equals(null));
+      var expectedData =
+          Map.fromEntries(columns.map((c) => MapEntry(c['name'], c['name'])));
+
+      var crud = db.select('select * from ps_crud').first;
+      var crudData = jsonDecode(crud['data']);
+      expect(crud['tx_id'], equals(1));
+      expect(
+          crudData,
+          equals({
+            'op': 'PUT',
+            'type': 'items',
+            'id': 'test_id',
+            'data': expectedData
+          }));
+    };
+
+    for (var numberOfColumns in [1, 49, 50, 51, 63, 64, 100, 1999]) {
+      test('crud test with $numberOfColumns columns', () async {
+        runCrudTest(numberOfColumns);
+      });
+      test('crud test with $numberOfColumns columns - local_only', () async {
+        runCrudTestLocalOnly(numberOfColumns);
+      });
+
+      test('crud test with $numberOfColumns columns - insert_only', () async {
+        runCrudTestInsertOnly(numberOfColumns);
+      });
+    }
+  });
+}


### PR DESCRIPTION
We currently use JSON to store all synced data, with views to present it as a normal table.

Part of this is using triggers to persist updates (insert/update/delete), using the SQLite `json_object` function to convert the data back to JSON.

The issue is that SQLite limits function calls to 100 arguments by default, and this can be increased to a maximum of 127. Since `json_object` requires 2 arguments for each value (key + value), this means we can have a maximum of 50 or 63 columns, depending on the value of SQLITE_MAX_FUNCTION_ARG.

The change here works around the issue by building up the json object in chunks of 50 columns, then merge together using a new `powersync_json_merge` function. This takes the form of `powersync_json_merge(json_object('a', 1, 'b', 2), json_object('c', 3, 'd', 4))`. This is slightly less efficient than a single json_object call, so we only do this when there are more than 50 columns in a table.

With SQLITE_MAX_FUNCTION_ARG = 100, this would give us a maximum of `100 * 50 = 5000` columns. However, SQLITE_MAX_COLUMN with a default of 2000 is still a limiting factor, so we have a practical limit of 1999 columns (excluding id).
