### PR TITLE
[WIP] Rewrite the "sync_local" query

### DIFF
--- a/crates/core/src/sync_local.rs
+++ b/crates/core/src/sync_local.rs
@@ -146,6 +146,7 @@ SELECT
         if tables.contains(&table_name) {
             let quoted = quote_internal_name(type_name, false);
 
+            // is_err() is essentially a NULL check here
             if data.is_err() {
                 // DELETE
                 let delete_statement = db
@@ -163,6 +164,7 @@ SELECT
                 insert_statement.exec()?;
             }
         } else {
+            // is_err() is essentially a NULL check here
             if data.is_err() {
                 // DELETE
                 // language=SQLite


### PR DESCRIPTION
#40 fixed a performance issue in initial/bulk sync when there are many duplicate row_ids, but decreased the performance slightly for the general case. This attempts to optimize it again, mostly by removing the second temp b-tree used in query execution.

This does not make a massive difference in overall initial sync performance. On my machine, with 1M ops, the query time reduces from around 5s -> 3s, versus a total initial sync time of 60s. So it's not a big gain overall, but this is the slowest query that locks the database for writes and cannot be split into smaller subqueries, so any optimization here helps with app responsiveness.

There is another query form added in the comments, which can take the initial sync query time down in the above case to under 2s (with no temp b-tree at all), but it doesn't cater for incremental updates. It needs some stats tracking / heuristics added to know when to use one query or the other, so I'm leaving that for later.

The temp b-trees used by this query could also be related to `RangeError: Maximum call stack size exceeded` errors seen on iOS, as well as `disk I/O error` occasionally seen on Android, when SQLite is configured to use files for temporary storage. While those issues have other workarounds, any changes to reduce temporary b-trees here could help.

TODO:
 * [ ] Regression testing
 * [ ] Test real-world performance