### PR TITLE
Update CocoaPods in CI

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -24,7 +24,7 @@ jobs:
       - name: setup-cocoapods
         uses: maxim-lobanov/setup-cocoapods@v1
         with:
-          version: 1.12.1
+          version: 1.16.2
 
       - name: Build iOS & macOS xcframework
         run: |


### PR DESCRIPTION
This fixes the `pod lib lint` command previously causing CI failures.