### PR TITLE
Clear sync completions in `powersync_clear`

### DIFF
--- a/crates/core/src/view_admin.rs
+++ b/crates/core/src/view_admin.rs
@@ -162,6 +162,7 @@ DELETE FROM ps_buckets;
 DELETE FROM ps_untyped;
 DELETE FROM ps_updated_rows;
 DELETE FROM ps_kv WHERE key != 'client_id';
+DELETE FROM ps_sync_state;
 ",
     )?;
 

--- a/dart/test/sync_test.dart
+++ b/dart/test/sync_test.dart
@@ -182,6 +182,21 @@ void main() {
             isNotEmpty);
       }
     });
+
+    test('clearing database clears sync status', () {
+      pushSyncData('prio1', '1', 'row-0', 'PUT', {'col': 'hi'});
+
+      expect(
+          pushCheckpointComplete(
+              '1', null, [_bucketChecksum('prio1', 1, checksum: 0)]),
+          isTrue);
+      expect(db.select('SELECT powersync_last_synced_at() AS r').single,
+          {'r': isNotNull});
+
+      db.execute('SELECT powersync_clear(0)');
+      expect(db.select('SELECT powersync_last_synced_at() AS r').single,
+          {'r': isNull});
+    });
   });
 }
 


### PR DESCRIPTION
Calling `powersync_clear` should also reset the state of `powersync_last_synced_at()`. It did that when that function was based on the KV-store, but the implementation did not reset the new `ps_sync_state`.
