### PR TITLE
Release version 0.3.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "powersync_core"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "bytes",
  "num-derive",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "cc",
  "powersync_core",
@@ -331,7 +331,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "sqlite3"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ inherits = "release"
 inherits = "wasm"
 
 [workspace.package]
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "co.powersync"
-version = "0.3.10"
+version = "0.3.11"
 description = "PowerSync Core SQLite Extension"
 
 repositories {

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.3.10"
+  "version": "0.3.11"
 }

--- a/crates/core/src/sync_local.rs
+++ b/crates/core/src/sync_local.rs
@@ -63,7 +63,7 @@ impl<'a> SyncOperation<'a> {
 
     fn can_apply_sync_changes(&self) -> Result<bool, SQLiteError> {
         // Don't publish downloaded data until the upload queue is empty (except for downloaded data
-        //in priority 0, which is published earlier).
+        // in priority 0, which is published earlier).
 
         let needs_check = match &self.partial {
             Some(p) => !p.priority.may_publish_with_outstanding_uploads(),

--- a/dart/test/sync_test.dart
+++ b/dart/test/sync_test.dart
@@ -180,6 +180,10 @@ void main() {
 
         expect(db.select('select 1 from ps_sync_state where priority = ?', [i]),
             isNotEmpty);
+        // A sync at this priority includes all higher priorities too, so they
+        // should be cleared.
+        expect(db.select('select 1 from ps_sync_state where priority < ?', [i]),
+            isEmpty);
       }
     });
 
@@ -192,10 +196,13 @@ void main() {
           isTrue);
       expect(db.select('SELECT powersync_last_synced_at() AS r').single,
           {'r': isNotNull});
+      expect(db.select('SELECT priority FROM ps_sync_state').single,
+          {'priority': 2147483647});
 
       db.execute('SELECT powersync_clear(0)');
       expect(db.select('SELECT powersync_last_synced_at() AS r').single,
           {'r': isNull});
+      expect(db.select('SELECT * FROM ps_sync_state'), hasLength(0));
     });
   });
 }

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.3.10'
+  s.version          = '0.3.11'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -28,9 +28,9 @@ function createXcframework() {
   <key>MinimumOSVersion</key>
   <string>11.0</string>
   <key>CFBundleVersion</key>
-  <string>0.3.10</string>
+  <string>0.3.11</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.3.10</string>
+  <string>0.3.11</string>
 </dict>
 </plist>
 EOF


### PR DESCRIPTION
Version 0.3.10 introduced a regression causing `powersync_clear` to no longer reset information about the sync state. This release fixes that.