### PR TITLE
Fix migration tests

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,9 +1,11 @@
 on:
   push:
+  pull_request:
 name: "android"
 jobs:
   build:
     name: Building Android
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,9 +1,11 @@
 on:
   push:
+  pull_request:
 name: "ios"
 jobs:
   build:
     name: Building iOS
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,9 +1,11 @@
 on:
   push:
+  pull_request:
 name: "linux"
 jobs:
   build_x86_64:
     name: Building Linux x86_64
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -21,6 +23,7 @@ jobs:
 
   build_aarch64:
     name: Building Linux aarch64
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-arm64
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,9 +1,11 @@
 on:
   push:
+  pull_request:
 name: "macos"
 jobs:
   build_macOS_aarch64:
     name: Building macOS aarch64
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -21,6 +23,7 @@ jobs:
 
   build_macOS_x64:
     name: Building macOS x64
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,11 @@
 on:
   push:
+  pull_request:
 name: "tests"
 jobs:
   build:
     name: Testing on ${{ matrix.os }}
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     name: Testing with Valgrind on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     strategy:
       matrix:
         include:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,9 +1,11 @@
 on:
   push:
+  pull_request:
 name: "wasm"
 jobs:
   build_wasm:
     name: Basic WASM build
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,9 +1,11 @@
 on:
   push:
+  pull_request:
 name: "windows"
 jobs:
   build_windows:
     name: Building Windows
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3

--- a/dart/test/utils/migration_fixtures.dart
+++ b/dart/test/utils/migration_fixtures.dart
@@ -415,6 +415,8 @@ END
       SELECT CASE
       WHEN (NEW.id IS NULL)
       THEN RAISE (FAIL, 'id is required')
+      WHEN (typeof(NEW.id) != 'text')
+      THEN RAISE (FAIL, 'id should be text')
       END;
       INSERT INTO "ps_data__lists"
       SELECT NEW.id, json_object('description', NEW."description");
@@ -478,6 +480,8 @@ END
       SELECT CASE
       WHEN (NEW.id IS NULL)
       THEN RAISE (FAIL, 'id is required')
+      WHEN (typeof(NEW.id) != 'text')
+      THEN RAISE (FAIL, 'id should be text')
       END;
       INSERT INTO "ps_data__lists"
       SELECT NEW.id, json_object('description', NEW."description");


### PR DESCRIPTION
Fix test fixtures after #65.

This now also configures the tests to be able to run on pull requests from external contributors (after approval), to catch these type of issues earlier. The `if` in the tests is so that a pull request by a core contributor doesn't trigger the workflow via both `push:` and `pull_request:` runs - that becomes a lot.