### PR TITLE
Fix unecessary schema changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "powersync_core"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "bytes",
  "const_format",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "cc",
  "powersync_core",
@@ -375,7 +375,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "sqlite3"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ inherits = "release"
 inherits = "wasm"
 
 [workspace.package]
-version = "0.3.13"
+version = "0.3.14"
 edition = "2021"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "co.powersync"
-version = "0.3.13"
+version = "0.3.14"
 description = "PowerSync Core SQLite Extension"
 
 repositories {

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.3.13"
+  "version": "0.3.14"
 }

--- a/crates/core/src/view_admin.rs
+++ b/crates/core/src/view_admin.rs
@@ -213,7 +213,7 @@ fn setup_internal_views(db: *mut sqlite::sqlite3) -> Result<(), ResultCode> {
     AS SELECT
         view.name name,
         view.sql sql,
-        ifnull(trigger1.sql, '') delete_trigger_sql,
+        ifnull(group_concat(trigger1.sql, ';\n' ORDER BY trigger1.name DESC), '') delete_trigger_sql,
         ifnull(trigger2.sql, '') insert_trigger_sql,
         ifnull(trigger3.sql, '') update_trigger_sql
         FROM sqlite_master view
@@ -223,7 +223,8 @@ fn setup_internal_views(db: *mut sqlite::sqlite3) -> Result<(), ResultCode> {
             ON trigger2.tbl_name = view.name AND trigger2.type = 'trigger' AND trigger2.name GLOB 'ps_view_insert*'
         LEFT JOIN sqlite_master trigger3
             ON trigger3.tbl_name = view.name AND trigger3.type = 'trigger' AND trigger3.name GLOB 'ps_view_update*'
-        WHERE view.type = 'view' AND view.sql GLOB  '*-- powersync-auto-generated';
+        WHERE view.type = 'view' AND view.sql GLOB  '*-- powersync-auto-generated'
+        GROUP BY view.name;
 
     CREATE TRIGGER IF NOT EXISTS powersync_views_insert
     INSTEAD OF INSERT ON powersync_views

--- a/crates/core/src/views.rs
+++ b/crates/core/src/views.rs
@@ -137,6 +137,7 @@ END"
         if table_info.flags.include_metadata() {
             let trigger_name = quote_identifier_prefixed("ps_view_delete2_", view_name);
             write!(&mut trigger,  "\
+;
 CREATE TRIGGER {trigger_name}
 INSTEAD OF UPDATE ON {quoted_name}
 FOR EACH ROW

--- a/crates/core/src/views.rs
+++ b/crates/core/src/views.rs
@@ -129,7 +129,7 @@ DELETE FROM {internal_name} WHERE id = OLD.id;
 INSERT INTO powersync_crud_(data) VALUES(json_object('op', 'DELETE', 'type', {type_string}, 'id', OLD.id{old_fragment}));
 INSERT OR IGNORE INTO ps_updated_rows(row_type, row_id) VALUES({type_string}, OLD.id);
 INSERT OR REPLACE INTO ps_buckets(name, last_op, target_op) VALUES('$local', 0, {MAX_OP_ID});
-END;"
+END"
         );
 
         // The DELETE statement can't include metadata for the delete operation, so we create
@@ -146,7 +146,7 @@ DELETE FROM {internal_name} WHERE id = NEW.id;
 INSERT INTO powersync_crud_(data) VALUES(json_object('op', 'DELETE', 'type', {type_string}, 'id', NEW.id{old_fragment}, 'metadata', NEW._metadata));
 INSERT OR IGNORE INTO ps_updated_rows(row_type, row_id) VALUES({type_string}, NEW.id);
 INSERT OR REPLACE INTO ps_buckets(name, last_op, target_op) VALUES('$local', 0, {MAX_OP_ID});
-END;"
+END"
                     ).expect("writing to string should be infallible");
         }
 

--- a/dart/test/schema_test.dart
+++ b/dart/test/schema_test.dart
@@ -1,0 +1,267 @@
+import 'dart:convert';
+
+import 'package:sqlite3/common.dart';
+import 'package:test/test.dart';
+
+import 'utils/native_test_utils.dart';
+
+void main() {
+  late CommonDatabase db;
+
+  setUp(() async {
+    db = openTestDatabase();
+  });
+
+  tearDown(() {
+    db.dispose();
+  });
+
+  group('Schema Tests', () {
+    test('Schema versioning', () {
+      // Test that powersync_replace_schema() is a no-op when the schema is not
+      // modified.
+      db.execute('SELECT powersync_replace_schema(?)', [json.encode(schema)]);
+
+      final [versionBefore] = db.select('PRAGMA schema_version');
+      db.execute('SELECT powersync_replace_schema(?)', [json.encode(schema)]);
+      final [versionAfter] = db.select('PRAGMA schema_version');
+
+      // No change
+      expect(versionAfter['schema_version'],
+          equals(versionBefore['schema_version']));
+
+      db.execute('SELECT powersync_replace_schema(?)', [json.encode(schema2)]);
+      final [versionAfter2] = db.select('PRAGMA schema_version');
+
+      // Updated
+      expect(versionAfter2['schema_version'],
+          greaterThan(versionAfter['schema_version'] as int));
+
+      db.execute('SELECT powersync_replace_schema(?)', [json.encode(schema3)]);
+      final [versionAfter3] = db.select('PRAGMA schema_version');
+
+      // Updated again (index)
+      expect(versionAfter3['schema_version'],
+          greaterThan(versionAfter2['schema_version'] as int));
+    });
+  });
+}
+
+final schema = {
+  "tables": [
+    {
+      "name": "assets",
+      "view_name": null,
+      "local_only": false,
+      "insert_only": false,
+      "columns": [
+        {"name": "created_at", "type": "TEXT"},
+        {"name": "make", "type": "TEXT"},
+        {"name": "model", "type": "TEXT"},
+        {"name": "serial_number", "type": "TEXT"},
+        {"name": "quantity", "type": "INTEGER"},
+        {"name": "user_id", "type": "TEXT"},
+        {"name": "weight", "type": "REAL"},
+        {"name": "description", "type": "TEXT"}
+      ],
+      "indexes": [
+        {
+          "name": "makemodel",
+          "columns": [
+            {"name": "make", "ascending": true, "type": "TEXT"},
+            {"name": "model", "ascending": true, "type": "TEXT"}
+          ]
+        }
+      ]
+    },
+    {
+      "name": "customers",
+      "view_name": null,
+      "local_only": false,
+      "insert_only": false,
+      "columns": [
+        {"name": "name", "type": "TEXT"},
+        {"name": "email", "type": "TEXT"}
+      ],
+      "indexes": []
+    },
+    {
+      "name": "logs",
+      "view_name": null,
+      "local_only": false,
+      "insert_only": true,
+      "columns": [
+        {"name": "level", "type": "TEXT"},
+        {"name": "content", "type": "TEXT"}
+      ],
+      "indexes": []
+    },
+    {
+      "name": "credentials",
+      "view_name": null,
+      "local_only": true,
+      "insert_only": false,
+      "columns": [
+        {"name": "key", "type": "TEXT"},
+        {"name": "value", "type": "TEXT"}
+      ],
+      "indexes": []
+    },
+    {
+      "name": "aliased",
+      "view_name": "test1",
+      "local_only": false,
+      "insert_only": false,
+      "columns": [
+        {"name": "name", "type": "TEXT"}
+      ],
+      "indexes": []
+    }
+  ]
+};
+
+final schema2 = {
+  "tables": [
+    {
+      "name": "assets",
+      "view_name": null,
+      "local_only": false,
+      "insert_only": false,
+      "columns": [
+        {"name": "created_at", "type": "TEXT"},
+        {"name": "make", "type": "TEXT"},
+        {"name": "model", "type": "TEXT"},
+        {"name": "serial_number", "type": "TEXT"},
+        {"name": "quantity", "type": "INTEGER"},
+        {"name": "user_id", "type": "TEXT"},
+        {"name": "weights", "type": "REAL"},
+        {"name": "description", "type": "TEXT"}
+      ],
+      "indexes": [
+        {
+          "name": "makemodel",
+          "columns": [
+            {"name": "make", "ascending": true, "type": "TEXT"},
+            {"name": "model", "ascending": true, "type": "TEXT"}
+          ]
+        }
+      ]
+    },
+    {
+      "name": "customers",
+      "view_name": null,
+      "local_only": false,
+      "insert_only": false,
+      "columns": [
+        {"name": "name", "type": "TEXT"},
+        {"name": "email", "type": "TEXT"}
+      ],
+      "indexes": []
+    },
+    {
+      "name": "logs",
+      "view_name": null,
+      "local_only": false,
+      "insert_only": true,
+      "columns": [
+        {"name": "level", "type": "TEXT"},
+        {"name": "content", "type": "TEXT"}
+      ],
+      "indexes": []
+    },
+    {
+      "name": "credentials",
+      "view_name": null,
+      "local_only": true,
+      "insert_only": false,
+      "columns": [
+        {"name": "key", "type": "TEXT"},
+        {"name": "value", "type": "TEXT"}
+      ],
+      "indexes": []
+    },
+    {
+      "name": "aliased",
+      "view_name": "test1",
+      "local_only": false,
+      "insert_only": false,
+      "columns": [
+        {"name": "name", "type": "TEXT"}
+      ],
+      "indexes": []
+    }
+  ]
+};
+
+final schema3 = {
+  "tables": [
+    {
+      "name": "assets",
+      "view_name": null,
+      "local_only": false,
+      "insert_only": false,
+      "columns": [
+        {"name": "created_at", "type": "TEXT"},
+        {"name": "make", "type": "TEXT"},
+        {"name": "model", "type": "TEXT"},
+        {"name": "serial_number", "type": "TEXT"},
+        {"name": "quantity", "type": "INTEGER"},
+        {"name": "user_id", "type": "TEXT"},
+        {"name": "weights", "type": "REAL"},
+        {"name": "description", "type": "TEXT"}
+      ],
+      "indexes": [
+        {
+          "name": "makemodel",
+          "columns": [
+            {"name": "make", "ascending": true, "type": "TEXT"},
+            {"name": "model", "ascending": false, "type": "TEXT"}
+          ]
+        }
+      ]
+    },
+    {
+      "name": "customers",
+      "view_name": null,
+      "local_only": false,
+      "insert_only": false,
+      "columns": [
+        {"name": "name", "type": "TEXT"},
+        {"name": "email", "type": "TEXT"}
+      ],
+      "indexes": []
+    },
+    {
+      "name": "logs",
+      "view_name": null,
+      "local_only": false,
+      "insert_only": true,
+      "columns": [
+        {"name": "level", "type": "TEXT"},
+        {"name": "content", "type": "TEXT"}
+      ],
+      "indexes": []
+    },
+    {
+      "name": "credentials",
+      "view_name": null,
+      "local_only": true,
+      "insert_only": false,
+      "columns": [
+        {"name": "key", "type": "TEXT"},
+        {"name": "value", "type": "TEXT"}
+      ],
+      "indexes": []
+    },
+    {
+      "name": "aliased",
+      "view_name": "test1",
+      "local_only": false,
+      "insert_only": false,
+      "columns": [
+        {"name": "name", "type": "TEXT"}
+      ],
+      "indexes": []
+    }
+  ]
+};

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.3.13'
+  s.version          = '0.3.14'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -28,9 +28,9 @@ function createXcframework() {
   <key>MinimumOSVersion</key>
   <string>11.0</string>
   <key>CFBundleVersion</key>
-  <string>0.3.13</string>
+  <string>0.3.14</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.3.13</string>
+  <string>0.3.14</string>
 </dict>
 </plist>
 EOF


### PR DESCRIPTION
We expect calls to `powersync_replace_schema(?)` with a schema that is already present in the database to be a noop. Unfortunately, version 0.3.13 had a regression here because the `CREATE TRIGGER` statement for deletes includes a trailing semicolon. This semicolon is not added to `sqlite_schema` (which is the source we use for diffs to determine which views to update), meaning that all views are re-created every time.

This was caught by [a Dart CI failure](https://github.com/powersync-ja/powersync.dart/actions/runs/14646075760/job/41100628559?pr=271), so I've copied the test into this repository. I've also bumped the version number so that we can do another release to get this out quickly.