### PR TITLE
Move central publishing to GH actions

### DIFF
--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -39,7 +39,7 @@ runs:
       if: ${{ inputs.sign-publication == '1' }}
       run: |
         cd android
-        ./gradlew build publishAllPublicationsToHereRepository -PgpgKey=${{ inputs.gpg-key }} -PgpgPassword=${{ inputs.gpg-password }}
+        ./gradlew build zipPublication -PgpgKey=${{ inputs.gpg-key }} -PgpgPassword=${{ inputs.gpg-password }}
         ls -lh build/outputs/aar
         find build/repository
 
@@ -48,7 +48,7 @@ runs:
       if: ${{ inputs.sign-publication == '0' }}
       run: |
         cd android
-        ./gradlew build publishAllPublicationsToHereRepository -PsignPublication=0
+        ./gradlew build zipPublication -PsignPublication=0
         ls -lh build/outputs/aar
         find build/repository
 

--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -1,12 +1,9 @@
 name: "Build Android library"
 description: "Create artifact for Android library"
 inputs:
-  gpg-key:
-    required: false
-    description: "The GPG key to use when signing the publication"
-  gpg-password:
-    required: false
-    description: "Password for the GPG key."
+  sign-publication:
+    description: "Whether to sign the built library"
+    default: '1'
 
 runs:
   using: "composite"
@@ -31,14 +28,21 @@ runs:
           i686-linux-android
         cargo install cargo-ndk
     
-    - name: Build for Android
+    - name: Build signed library
       shell: bash
-      env:
-        GPG_PRIVATE_KEY: ${{ inputs.gpg-key }}
-        GPG_PASSWORD: ${{ inputs.gpg-password }}
+      if: ${{ inputs.sign-publication == '1' }}
       run: |
         cd android
-        ./gradlew build publishAllPublicationsToHereRepository
+        ./gradlew build publishAllPublicationsToHereRepository -PgpgKey=${{ secrets.GPG_PRIVATE_KEY }} -PgpgPassword=${{ secrets.GPG_PASSWORD }}
+        ls -lh build/outputs/aar
+        find build/repository
+
+    - name: Build library without signing
+      shell: bash
+      if: ${{ inputs.sign-publication == '0' }}
+      run: |
+        cd android
+        ./gradlew build publishAllPublicationsToHereRepository -PsignPublication=0
         ls -lh build/outputs/aar
         find build/repository
 

--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -4,6 +4,12 @@ inputs:
   sign-publication:
     description: "Whether to sign the built library"
     default: '1'
+  gpg-key:
+    required: false
+    description: "The GPG key to use when signing the publication"
+  gpg-password:
+    required: false
+    description: "Password for the GPG key."
 
 runs:
   using: "composite"
@@ -33,7 +39,7 @@ runs:
       if: ${{ inputs.sign-publication == '1' }}
       run: |
         cd android
-        ./gradlew build publishAllPublicationsToHereRepository -PgpgKey=${{ secrets.GPG_PRIVATE_KEY }} -PgpgPassword=${{ secrets.GPG_PASSWORD }}
+        ./gradlew build publishAllPublicationsToHereRepository -PgpgKey=${{ inputs.gpg-key }} -PgpgPassword=${{ inputs.gpg-password }}
         ls -lh build/outputs/aar
         find build/repository
 

--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -1,0 +1,56 @@
+name: "Build Android library"
+description: "Create artifact for Android library"
+inputs:
+  gpg-key:
+    required: false
+    description: "The GPG key to use when signing the publication"
+  gpg-password:
+    required: false
+    description: "Password for the GPG key."
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - uses: actions/setup-java@v4
+      with:
+        distribution: "temurin"
+        java-version: "17"
+
+    - name: Validate Gradle wrapper
+      uses: gradle/actions/wrapper-validation@v4
+
+    - name: Setup
+      shell: bash
+      run: |
+        rustup toolchain install nightly-2025-04-15-x86_64-unknown-linux-gnu
+        rustup component add rust-src --toolchain nightly-2025-04-15-x86_64-unknown-linux-gnu
+        rustup target add \
+          aarch64-linux-android \
+          armv7-linux-androideabi \
+          x86_64-linux-android \
+          i686-linux-android
+        cargo install cargo-ndk
+    
+    - name: Build for Android
+      shell: bash
+      env:
+        GPG_PRIVATE_KEY: ${{ inputs.gpg-key }}
+        GPG_PASSWORD: ${{ inputs.gpg-password }}
+      run: |
+        cd android
+        ./gradlew build publishAllPublicationsToHereRepository
+        ls -lh build/outputs/aar
+        find build/repository
+
+    - name: Upload binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: android-library
+        retention-days: 1
+        compression-level: 0 # We're uploading a zip, no need to compress again
+        path: android/build/distributions/powersync_android.zip
+        if-no-files-found: error

--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -11,10 +11,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-
     - uses: actions/setup-java@v4
       with:
         distribution: "temurin"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,5 +8,8 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Build Android
         uses: ./.github/actions/android

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,38 +8,5 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: "17"
-
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
-
-      - name: Setup
-        run: |
-          rustup toolchain install nightly-2025-04-15-x86_64-unknown-linux-gnu
-          rustup component add rust-src --toolchain nightly-2025-04-15-x86_64-unknown-linux-gnu
-          rustup target add \
-            aarch64-linux-android \
-            armv7-linux-androideabi \
-            x86_64-linux-android \
-            i686-linux-android
-          cargo install cargo-ndk
-
-      - name: Build for Android
-        run: |
-          cd android
-          ./gradlew build
-          ls -lh build/outputs/aar
-
-      - name: Upload Android library
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-library
-          path: |
-            android/build/outputs/aar/
+      - name: Build Android
+        uses: ./.github/actions/android

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,3 +13,5 @@ jobs:
           submodules: true
       - name: Build Android
         uses: ./.github/actions/android
+        with:
+          sign-publication: '0'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
           submodules: true
       - name: Build Android
         uses: ./.github/actions/android
+        with:
+          gpg-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-password: ${{ secrets.GPG_PASSWORD }}
 
   publish_android:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,6 @@ jobs:
           submodules: true
       - name: Build Android
         uses: ./.github/actions/android
-        with:
-          gpg-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-password: ${{ secrets.GPG_PASSWORD }}
 
   publish_android:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
     name: Build Android
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Build Android
         uses: ./.github/actions/android
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,8 +68,8 @@ jobs:
           curl --request POST \
             --header 'Authorization: Bearer ${{ secrets.CENTRAL_AUTH }}' \
             --form bundle=@powersync_android.zip \
-            https://central.sonatype.com/api/v1/publisher/upload
-      
+            'https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC'
+
       - name: Upload binary
         uses: ./.github/actions/upload
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,45 +33,42 @@ jobs:
           body="Release $tag"
           gh release create --draft "$tag" --title "$tag" --notes "$body"
 
+  build_android:
+    name: Build Android
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Android
+        uses: ./.github/actions/android
+
   publish_android:
     permissions:
       contents: read
       packages: write
     name: Publish Android
-    needs: [draft_release]
+    needs: [draft_release, build_android]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          submodules: true
+          fetch-depth: 0
 
-      - uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: "17"
+      - uses: actions/download-artifact@v4
+        name: android-library
 
-      - name: Setup
-        run: |
-          rustup toolchain install nightly-2025-04-15-x86_64-unknown-linux-gnu
-          rustup component add rust-src --toolchain nightly-2025-04-15-x86_64-unknown-linux-gnu
-          rustup target add \
-            aarch64-linux-android \
-            armv7-linux-androideabi \
-            x86_64-linux-android \
-            i686-linux-android
-          cargo install cargo-ndk
-
-      - name: Publish for Android
+      - name: Publish to Maven Central
         if: ${{ inputs.publish }}
         run: |
-          cd android
-          ./gradlew publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+          curl --request POST \
+            --header 'Authorization: Bearer ${{ secrets.CENTRAL_AUTH }}' \
+            --form bundle=@powersync-android.zip \
+            https://central.sonatype.com/api/v1/publisher/upload
+      
+      - name: Upload binary
+        uses: ./.github/actions/upload
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          file-name: powersync-android.zip
+          tag: ${{ needs.draft_release.outputs.tag }}
 
   publish_ios_pod_and_spm_package:
     name: Publish iOS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,14 +59,15 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/download-artifact@v4
-        name: android-library
+        with:
+          name: android-library
 
       - name: Publish to Maven Central
         if: ${{ inputs.publish }}
         run: |
           curl --request POST \
             --header 'Authorization: Bearer ${{ secrets.CENTRAL_AUTH }}' \
-            --form bundle=@powersync-android.zip \
+            --form bundle=@powersync_android.zip \
             https://central.sonatype.com/api/v1/publisher/upload
       
       - name: Upload binary

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,7 +28,7 @@ The above does the following:
 
 1. Create a draft GitHub release.
 2. Build the xcframework for iOS and macOS, and upload to GitHub (attached to the above release).
-3. Build and publish an Android aar to Sonatype. Afterwards,you can monitor the status of the publishing step [here](https://central.sonatype.com/publishing/deployments).
+3. Build and publish an Android aar to Sonatype. Afterwards, you can monitor the status of the publishing step [here](https://central.sonatype.com/publishing/deployments).
 
 Publish the cocoapod:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,16 +28,7 @@ The above does the following:
 
 1. Create a draft GitHub release.
 2. Build the xcframework for iOS and macOS, and upload to GitHub (attached to the above release).
-3. Build and publish an Android aar to Sonatype staging.
-
-Once that is done, go to the Maven staging repository, and "Close", wait, and "Release" the
-repository:
-
-https://s01.oss.sonatype.org/#stagingRepositories
-
-Docs: https://central.sonatype.org/publish/release/
-
-Go to GitHub Releases on the repository, update the description, then "Publish Release".
+3. Build and publish an Android aar to Sonatype. Afterwards,you can monitor the status of the publishing step [here](https://central.sonatype.com/publishing/deployments).
 
 Publish the cocoapod:
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     id("signing")
 }
 
-group = "co.powersync"
+group = "com.powersync"
 version = "0.4.1"
 description = "PowerSync Core SQLite Extension"
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -170,14 +170,18 @@ publishing {
 }
 
 signing {
-    val privateKey = System.getenv("GPG_PRIVATE_KEY")
+    val sign = providers.gradleProperty("signPublication").getOrElse("1")
 
-    if (privateKey == null || privateKey == "null") {
-        // Don't sign the publication.
-    } else {
-        var signingKey = String(Base64.getDecoder().decode(System.getenv("GPG_PRIVATE_KEY"))).trim()
-        var signingPassword = System.getenv("GPG_PASSWORD")
-        useInMemoryPgpKeys(signingKey, signingPassword)
+    if (sign != "0") {
+        val key = providers.gradleProperty("gpgKey")
+        val password = providers.gradleProperty("gpgPassword")
+
+        if (key.isPresent()) {
+            val signingKey = String(Base64.getDecoder().decode(key.get())).trim()
+            useInMemoryPgpKeys(signingKey, password.get())
+        } else {
+            useGpgCmd()
+        }
 
         sign(publishing.publications)
     }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -16,6 +16,8 @@ group = "co.powersync"
 version = "0.4.1"
 description = "PowerSync Core SQLite Extension"
 
+val localRepo = uri("build/repository/")
+
 repositories {
     mavenCentral()
     google()
@@ -160,43 +162,34 @@ publishing {
     }
 
     repositories {
-        if (System.getenv("OSSRH_USERNAME") != null) {
-            maven {
-                name = "sonatype"
-                url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-                credentials {
-                    username = System.getenv("OSSRH_USERNAME")
-                    password = System.getenv("OSSRH_PASSWORD")
-                }
-            }
-        }
-
-        if (System.getenv("GITHUB_ACTOR") != null) {
-            maven {
-                name = "GitHubPackages"
-                url = uri("https://maven.pkg.github.com/powersync-ja/powersync-sqlite-core")
-                credentials {
-                    username = System.getenv("GITHUB_ACTOR")
-                    password = System.getenv("GITHUB_TOKEN")
-                }
-            }
+        maven {
+            name = "here"
+            url = localRepo
         }
     }
 }
 
 signing {
     if (System.getenv("GPG_PRIVATE_KEY") == null) {
-        useGpgCmd()
+        // Don't sign the publication.
     } else {
         var signingKey = String(Base64.getDecoder().decode(System.getenv("GPG_PRIVATE_KEY"))).trim()
         var signingPassword = System.getenv("GPG_PASSWORD")
         useInMemoryPgpKeys(signingKey, signingPassword)
+
+        sign(publishing.publications)
     }
-    sign(publishing.publications)
 }
 
 tasks.withType<AbstractPublishToMaven>() {
     dependsOn(prefabAar)
+}
+
+val zipPublication by tasks.registering(Zip::class) {
+    dependsOn(tasks.named("publishAllPublicationsToHereRepository"))
+
+    archiveFileName.set("powersync_android.zip")
+    from(localRepo)
 }
 
 tasks.named("build") {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -170,7 +170,9 @@ publishing {
 }
 
 signing {
-    if (System.getenv("GPG_PRIVATE_KEY") == null) {
+    val privateKey = System.getenv("GPG_PRIVATE_KEY")
+
+    if (privateKey == null || privateKey == "null") {
         // Don't sign the publication.
     } else {
         var signingKey = String(Base64.getDecoder().decode(System.getenv("GPG_PRIVATE_KEY"))).trim()


### PR DESCRIPTION
This simplifies the Android build and prepares the adoption of the new uploading API to maven central.

1. Building the Android library has been moved into a separate action that is called both from the regular CI and the release flow. It will collect files to be uploaded as an artifact.
2. To publish to central, we know download that artifact and upload it with curl as [shown here](https://central.sonatype.org/publish/publish-portal-api/#uploading-a-deployment-bundle).