### PR TITLE
Fix typo in JS key encoding fix function

### DIFF
--- a/crates/core/src/fix_data.rs
+++ b/crates/core/src/fix_data.rs
@@ -130,18 +130,18 @@ fn powersync_remove_duplicate_key_encoding_impl(
 }
 
 create_sqlite_optional_text_fn!(
-    powersync_remote_duplicate_key_encoding,
+    powersync_remove_duplicate_key_encoding,
     powersync_remove_duplicate_key_encoding_impl,
-    "powersync_remote_duplicate_key_encoding"
+    "powersync_remove_duplicate_key_encoding"
 );
 
 pub fn register(db: *mut sqlite::sqlite3) -> Result<(), ResultCode> {
     db.create_function_v2(
-        "powersync_remote_duplicate_key_encoding",
+        "powersync_remove_duplicate_key_encoding",
         1,
         sqlite::UTF8 | sqlite::DETERMINISTIC,
         None,
-        Some(powersync_remote_duplicate_key_encoding),
+        Some(powersync_remove_duplicate_key_encoding),
         None,
         None,
         None,

--- a/dart/test/js_key_encoding_test.dart
+++ b/dart/test/js_key_encoding_test.dart
@@ -58,7 +58,7 @@ void main() {
 
     // Apply migration
     db.execute(
-        'UPDATE ps_oplog SET key = powersync_remote_duplicate_key_encoding(key);');
+        'UPDATE ps_oplog SET key = powersync_remove_duplicate_key_encoding(key);');
 
     [row] = db.select('select * from ps_oplog');
     expect(row['key'], 'items/1/subkey');


### PR DESCRIPTION
Rename `powersync_remote_duplicate_key_encoding` to `powersync_remove_duplicate_key_encoding` 🤦 