### PR TITLE
Rewrite the "sync_local" query

### DIFF
--- a/crates/core/src/sync_local.rs
+++ b/crates/core/src/sync_local.rs
@@ -114,7 +114,8 @@ impl<'a> SyncOperation<'a> {
             if self.data_tables.contains(&table_name) {
                 let quoted = quote_internal_name(type_name, false);
 
-                if !data.is_ok() {
+                // is_err() is essentially a NULL check here
+                if data.is_err() {
                     // DELETE
                     let delete_statement = self
                         .db
@@ -133,7 +134,7 @@ impl<'a> SyncOperation<'a> {
                     insert_statement.exec()?;
                 }
             } else {
-                if !data.is_ok() {
+                if data.is_err() {
                     // DELETE
                     // language=SQLite
                     let delete_statement = self

--- a/crates/core/src/sync_local.rs
+++ b/crates/core/src/sync_local.rs
@@ -107,7 +107,6 @@ impl<'a> SyncOperation<'a> {
         while statement.step().into_db_result(self.db)? == ResultCode::ROW {
             let type_name = statement.column_text(0)?;
             let id = statement.column_text(1)?;
-            let buckets = statement.column_int(3);
             let data = statement.column_text(2);
 
             let table_name = internal_table_name(type_name);
@@ -115,7 +114,7 @@ impl<'a> SyncOperation<'a> {
             if self.data_tables.contains(&table_name) {
                 let quoted = quote_internal_name(type_name, false);
 
-                if buckets == 0 {
+                if !data.is_ok() {
                     // DELETE
                     let delete_statement = self
                         .db
@@ -134,7 +133,7 @@ impl<'a> SyncOperation<'a> {
                     insert_statement.exec()?;
                 }
             } else {
-                if buckets == 0 {
+                if !data.is_ok() {
                     // DELETE
                     // language=SQLite
                     let delete_statement = self
@@ -189,28 +188,31 @@ impl<'a> SyncOperation<'a> {
                     .prepare_v2(
                         "\
 -- 1. Filter oplog by the ops added but not applied yet (oplog b).
---    SELECT DISTINCT / UNION is important for cases with many duplicate ids.
+--    We do not do any DISTINCT operation here, since that introduces a temp b-tree.
 WITH updated_rows AS (
-  SELECT DISTINCT b.row_type, b.row_id FROM ps_buckets AS buckets
-    CROSS JOIN ps_oplog AS b ON b.bucket = buckets.id
-  AND (b.op_id > buckets.last_applied_op)
-  UNION SELECT row_type, row_id FROM ps_updated_rows
+    SELECT b.row_type, b.row_id FROM ps_buckets AS buckets
+        CROSS JOIN ps_oplog AS b ON b.bucket = buckets.id
+        AND (b.op_id > buckets.last_applied_op)
+    UNION ALL SELECT row_type, row_id FROM ps_updated_rows
 )
 
--- 3. Group the objects from different buckets together into a single one (ops).
-SELECT b.row_type as type,
-    b.row_id as id,
-    r.data as data,
-    count(r.bucket) as buckets,
-    /* max() affects which row is used for 'data' */
-    max(r.op_id) as op_id
 -- 2. Find *all* current ops over different buckets for those objects (oplog r).
-FROM updated_rows b
-    LEFT OUTER JOIN ps_oplog AS r
-                ON r.row_type = b.row_type
-                    AND r.row_id = b.row_id
--- Group for (3)
-GROUP BY b.row_type, b.row_id",
+SELECT
+    b.row_type,
+    b.row_id,
+    (
+        -- 3. For each unique row, select the data from the latest oplog entry.
+        -- The max(r.op_id) clause is used to select the latest oplog entry.
+        -- The iif is to avoid the max(r.op_id) column ending up in the results.
+        SELECT iif(max(r.op_id), r.data, null)
+                 FROM ps_oplog r
+                WHERE r.row_type = b.row_type
+                  AND r.row_id = b.row_id
+
+    ) as data
+    FROM updated_rows b
+    -- Group for (2)
+    GROUP BY b.row_type, b.row_id;",
                     )
                     .into_db_result(self.db)?
             }
@@ -220,33 +222,37 @@ GROUP BY b.row_type, b.row_id",
                     .prepare_v2(
                         "\
 -- 1. Filter oplog by the ops added but not applied yet (oplog b).
---    SELECT DISTINCT / UNION is important for cases with many duplicate ids.
+--    We do not do any DISTINCT operation here, since that introduces a temp b-tree.
 WITH 
   involved_buckets (id) AS MATERIALIZED (
     SELECT id FROM ps_buckets WHERE ?1 IS NULL
       OR name IN (SELECT value FROM json_each(json_extract(?1, '$.buckets')))
   ),
   updated_rows AS (
-    SELECT DISTINCT FALSE as local, b.row_type, b.row_id FROM ps_buckets AS buckets
-      CROSS JOIN ps_oplog AS b ON b.bucket = buckets.id AND (b.op_id > buckets.last_applied_op)
-      WHERE buckets.id IN (SELECT id FROM involved_buckets)
+    SELECT b.row_type, b.row_id FROM ps_buckets AS buckets
+        CROSS JOIN ps_oplog AS b ON b.bucket = buckets.id
+        AND (b.op_id > buckets.last_applied_op)
+        WHERE buckets.id IN (SELECT id FROM involved_buckets)
   )
 
--- 3. Group the objects from different buckets together into a single one (ops).
-SELECT b.row_type as type,
-    b.row_id as id,
-    r.data as data,
-    count(r.bucket) as buckets,
-    /* max() affects which row is used for 'data' */
-    max(r.op_id) as op_id
 -- 2. Find *all* current ops over different buckets for those objects (oplog r).
-FROM updated_rows b
-    LEFT OUTER JOIN ps_oplog AS r
-               ON r.row_type = b.row_type
-                 AND r.row_id = b.row_id
-                 AND r.bucket IN (SELECT id FROM involved_buckets)
--- Group for (3)
-GROUP BY b.row_type, b.row_id",
+SELECT
+    b.row_type,
+    b.row_id,
+    (
+        -- 3. For each unique row, select the data from the latest oplog entry.
+        -- The max(r.op_id) clause is used to select the latest oplog entry.
+        -- The iif is to avoid the max(r.op_id) column ending up in the results.
+        SELECT iif(max(r.op_id), r.data, null)
+                 FROM ps_oplog r
+                WHERE r.row_type = b.row_type
+                  AND r.row_id = b.row_id
+                  AND r.bucket IN (SELECT id FROM involved_buckets)
+
+    ) as data
+    FROM updated_rows b
+    -- Group for (2)
+    GROUP BY b.row_type, b.row_id;",
                     )
                     .into_db_result(self.db)?;
                 stmt.bind_text(1, partial.args, Destructor::STATIC)?;

--- a/dart/pubspec.lock
+++ b/dart/pubspec.lock
@@ -293,10 +293,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite3
-      sha256: "310af39c40dd0bb2058538333c9d9840a2725ae0b9f77e4fd09ad6696aa8f66e"
+      sha256: c0503c69b44d5714e6abbf4c1f51a3c3cc42b75ce785f44404765e4635481d38
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.5"
+    version: "2.7.6"
   sqlite3_test:
     dependency: "direct dev"
     description:

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -5,7 +5,7 @@ description: Tests for powersync-sqlite-core
 environment:
   sdk: ^3.4.0
 dependencies:
-  sqlite3: ^2.4.5
+  sqlite3: ^2.7.6
 dev_dependencies:
   test: ^1.25.0
   file: ^7.0.1

--- a/dart/test/js_key_encoding_test.dart
+++ b/dart/test/js_key_encoding_test.dart
@@ -9,7 +9,9 @@ import 'package:test/test.dart';
 import 'utils/native_test_utils.dart';
 
 void main() {
-  final vfs = TestSqliteFileSystem(fs: const LocalFileSystem());
+  // Needs an unique name per test file to avoid concurrency issues
+  final vfs = TestSqliteFileSystem(
+      fs: const LocalFileSystem(), name: 'js-key-encoding-test-vfs');
   late CommonDatabase db;
 
   setUpAll(() {

--- a/dart/test/js_key_encoding_test.dart
+++ b/dart/test/js_key_encoding_test.dart
@@ -19,7 +19,7 @@ void main() {
   tearDownAll(() => sqlite3.unregisterVirtualFileSystem(vfs));
 
   setUp(() async {
-    db = openTestDatabase(vfs)
+    db = openTestDatabase(vfs: vfs)
       ..select('select powersync_init();')
       ..select('select powersync_replace_schema(?)', [json.encode(_schema)]);
   });

--- a/dart/test/perf_test.dart
+++ b/dart/test/perf_test.dart
@@ -17,7 +17,9 @@ void main() {
   });
 
   setUp(() async {
-    vfs = new TrackingFileSystem(parent: new InMemoryFileSystem());
+    // Needs an unique name per test file to avoid concurrency issues
+    vfs = new TrackingFileSystem(
+        parent: new InMemoryFileSystem(), name: 'perf-test-vfs');
     sqlite3.registerVirtualFileSystem(vfs, makeDefault: false);
     db = openTestDatabase(vfs: vfs, fileName: 'test.db');
   });

--- a/dart/test/perf_test.dart
+++ b/dart/test/perf_test.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+
+import 'package:sqlite3/common.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:test/test.dart';
+
+import 'utils/native_test_utils.dart';
+import 'utils/tracking_vfs.dart';
+import './schema_test.dart' show schema;
+
+void main() {
+  late TrackingFileSystem vfs;
+  late CommonDatabase db;
+
+  setUpAll(() {
+    loadExtension();
+  });
+
+  setUp(() async {
+    vfs = new TrackingFileSystem(parent: new InMemoryFileSystem());
+    sqlite3.registerVirtualFileSystem(vfs, makeDefault: false);
+    db = openTestDatabase(vfs: vfs, fileName: 'test.db');
+  });
+
+  tearDown(() {
+    db.dispose();
+    sqlite3.unregisterVirtualFileSystem(vfs);
+  });
+
+  setUp(() {
+    db.execute('SELECT powersync_replace_schema(?)', [json.encode(schema)]);
+    db.execute('''
+BEGIN TRANSACTION;
+
+WITH RECURSIVE generate_rows(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM generate_rows WHERE n < 200000
+)
+INSERT INTO ps_oplog (bucket, op_id, row_type, row_id, key, data, hash)
+SELECT 
+    (n % 10), -- Generate 10 different buckets
+    n,
+    'assets',
+    uuid(),
+    uuid(),
+    '{"description": "' || n || '", "make": "test", "model": "this is just filler data. this is just filler data. this is just filler data. this is just filler data. this is just filler data. this is just filler data. this is just filler data. "}',
+    (n * 17) % 1000000000 -- Some pseudo-random hash
+    
+FROM generate_rows;
+
+WITH RECURSIVE generate_rows(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM generate_rows WHERE n < 10
+)
+INSERT INTO ps_buckets (id, name, last_applied_op)
+SELECT 
+    (n % 10),
+    'bucket' || n,
+    10000
+    
+FROM generate_rows;
+
+COMMIT;
+''');
+    print('init stats: ${vfs.stats()}');
+
+    vfs.clearStats();
+  });
+
+  test('sync_local (full)', () {
+    var timer = Stopwatch()..start();
+    db.select('insert into powersync_operations(op, data) values(?, ?)',
+        ['sync_local', '']);
+    print('${timer.elapsed.inMilliseconds}ms ${vfs.stats()}');
+  });
+
+  test('sync_local (partial)', () {
+    var timer = Stopwatch()..start();
+    db.select('insert into powersync_operations(op, data) values(?, ?)', [
+      'sync_local',
+      jsonEncode({
+        'buckets': ['bucket0', 'bucket3', 'bucket4', 'bucket5', 'bucket6'],
+        'priority': 2
+      })
+    ]);
+    print('${timer.elapsed.inMilliseconds}ms ${vfs.stats()}');
+  });
+}

--- a/dart/test/sync_test.dart
+++ b/dart/test/sync_test.dart
@@ -22,7 +22,7 @@ void main() {
     late CommonDatabase db;
 
     setUp(() async {
-      db = openTestDatabase(vfs)
+      db = openTestDatabase(vfs: vfs)
         ..select('select powersync_init();')
         ..select('select powersync_replace_schema(?)', [json.encode(_schema)]);
     });

--- a/dart/test/sync_test.dart
+++ b/dart/test/sync_test.dart
@@ -10,7 +10,9 @@ import 'package:test/test.dart';
 import 'utils/native_test_utils.dart';
 
 void main() {
-  final vfs = TestSqliteFileSystem(fs: const LocalFileSystem());
+  // Needs an unique name per test file to avoid concurrency issues
+  final vfs =
+      TestSqliteFileSystem(fs: const LocalFileSystem(), name: 'sync-test-vfs');
 
   setUpAll(() {
     loadExtension();

--- a/dart/test/utils/native_test_utils.dart
+++ b/dart/test/utils/native_test_utils.dart
@@ -26,13 +26,14 @@ void applyOpenOverride() {
   });
 }
 
-CommonDatabase openTestDatabase([VirtualFileSystem? vfs]) {
+CommonDatabase openTestDatabase(
+    {VirtualFileSystem? vfs, String fileName = ':memory:'}) {
   applyOpenOverride();
   if (!didLoadExtension) {
     loadExtension();
   }
 
-  return sqlite3.open(':memory:', vfs: vfs?.name);
+  return sqlite3.open(fileName, vfs: vfs?.name);
 }
 
 void loadExtension() {

--- a/dart/test/utils/tracking_vfs.dart
+++ b/dart/test/utils/tracking_vfs.dart
@@ -1,0 +1,118 @@
+import 'dart:typed_data';
+
+import 'package:sqlite3/sqlite3.dart';
+
+final class TrackingFileSystem extends BaseVirtualFileSystem {
+  BaseVirtualFileSystem parent;
+  int tempReads = 0;
+  int tempWrites = 0;
+  int dataReads = 0;
+  int dataWrites = 0;
+
+  TrackingFileSystem({super.name = 'tracking', required this.parent});
+
+  @override
+  int xAccess(String path, int flags) {
+    return parent.xAccess(path, flags);
+  }
+
+  @override
+  void xDelete(String path, int syncDir) {
+    parent.xDelete(path, syncDir);
+  }
+
+  @override
+  String xFullPathName(String path) {
+    return parent.xFullPathName(path);
+  }
+
+  @override
+  XOpenResult xOpen(Sqlite3Filename path, int flags) {
+    final result = parent.xOpen(path, flags);
+    return (
+      outFlags: result.outFlags,
+      file: TrackingFile(
+          result.file, this, flags & SqlFlag.SQLITE_OPEN_DELETEONCLOSE != 0),
+    );
+  }
+
+  @override
+  void xSleep(Duration duration) {}
+
+  String stats() {
+    return "Reads: $dataReads + $tempReads | Writes: $dataWrites + $tempWrites";
+  }
+
+  void clearStats() {
+    tempReads = 0;
+    tempWrites = 0;
+    dataReads = 0;
+    dataWrites = 0;
+  }
+}
+
+class TrackingFile implements VirtualFileSystemFile {
+  final TrackingFileSystem vfs;
+  final VirtualFileSystemFile parentFile;
+  final bool deleteOnClose;
+
+  TrackingFile(this.parentFile, this.vfs, this.deleteOnClose);
+
+  @override
+  void xWrite(Uint8List buffer, int fileOffset) {
+    if (deleteOnClose) {
+      vfs.tempWrites++;
+    } else {
+      vfs.dataWrites++;
+    }
+    parentFile.xWrite(buffer, fileOffset);
+  }
+
+  @override
+  void xRead(Uint8List buffer, int offset) {
+    if (deleteOnClose) {
+      vfs.tempReads++;
+    } else {
+      vfs.dataReads++;
+    }
+    parentFile.xRead(buffer, offset);
+  }
+
+  @override
+  int xCheckReservedLock() {
+    return parentFile.xCheckReservedLock();
+  }
+
+  @override
+  void xClose() {
+    return parentFile.xClose();
+  }
+
+  @override
+  int xFileSize() {
+    return parentFile.xFileSize();
+  }
+
+  @override
+  void xLock(int mode) {
+    return parentFile.xLock(mode);
+  }
+
+  @override
+  void xSync(int flags) {
+    return parentFile.xSync(flags);
+  }
+
+  @override
+  void xTruncate(int size) {
+    return parentFile.xTruncate(size);
+  }
+
+  @override
+  void xUnlock(int mode) {
+    return parentFile.xUnlock(mode);
+  }
+
+  @override
+  int get xDeviceCharacteristics => parentFile.xDeviceCharacteristics;
+}


### PR DESCRIPTION
Supersedes #56. This is the same basic optimization as in that PR, but now also supports bucket priorities, and updated with the latest changes.

This now tracks filesystem operations (pages written/read) as the main metric to optimize for this query. It is not the only metric that matters, but it is consistent, and a good indication of real-world performance with large amounts of data on mobile and web platforms.

For the base test case, 500k rows:

```
# Data setup stats (for reference only)
init stats: Reads: 1348044 + 0 | Writes: 1188543 + 0 # (main db page operations) + (temp storage page operations)
# Before
4283ms Reads: 918018 + 531168 | Writes: 68904 + 521079
# After:
3800ms Reads: 1289503 + 5518 | Writes: 69023 + 5518
```

There is some increase in reads on the data db, but a massive reduction in temporary storage operations.
The above is with the default SQLite cache_size. If we set say `PRAGMA cache_size=-50000` (50MB), we can do 500k rows without using _any_ temporary storage with the changes here. With the previous query, temporary storage was already used after 30-40k rows.

There are further optimizations to be made for the initial sync or when we're re-syncing most of the data, but the gains here already significant.