### PR TITLE
Use serde to read tables and indexes from schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlite_nostd",
- "streaming-iterator",
  "uuid",
 ]
 
@@ -403,12 +402,6 @@ dependencies = [
  "sqlite3_allocator",
  "sqlite3_capi",
 ]
-
-[[package]]
-name = "streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "syn"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,7 +19,6 @@ num-traits = { version = "0.2.15", default-features = false }
 num-derive = "0.3"
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-streaming-iterator = { version = "0.1.9", default-features = false, features = ["alloc"] }
 const_format = "0.2.34"
 
 [dependencies.uuid]

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -66,3 +66,9 @@ impl From<serde_json::Error> for SQLiteError {
         SQLiteError(ResultCode::ABORT, Some(value.to_string()))
     }
 }
+
+impl From<core::fmt::Error> for SQLiteError {
+    fn from(value: core::fmt::Error) -> Self {
+        SQLiteError(ResultCode::INTERNAL, Some(format!("{}", value)))
+    }
+}

--- a/crates/core/src/fix_data.rs
+++ b/crates/core/src/fix_data.rs
@@ -117,7 +117,7 @@ fn remove_duplicate_key_encoding(key: &str) -> Option<String> {
 }
 
 fn powersync_remove_duplicate_key_encoding_impl(
-    ctx: *mut sqlite::context,
+    _ctx: *mut sqlite::context,
     args: &[*mut sqlite::value],
 ) -> Result<Option<String>, SQLiteError> {
     let arg = args.get(0).ok_or(ResultCode::MISUSE)?;

--- a/crates/core/src/schema/mod.rs
+++ b/crates/core/src/schema/mod.rs
@@ -1,11 +1,16 @@
 mod management;
 mod table_info;
 
+use alloc::vec::Vec;
+use serde::Deserialize;
 use sqlite::ResultCode;
 use sqlite_nostd as sqlite;
-pub use table_info::{
-    ColumnInfo, ColumnNameAndTypeStatement, DiffIncludeOld, TableInfo, TableInfoFlags,
-};
+pub use table_info::{Column, DiffIncludeOld, Table, TableInfoFlags};
+
+#[derive(Deserialize)]
+pub struct Schema {
+    tables: Vec<table_info::Table>,
+}
 
 pub fn register(db: *mut sqlite::sqlite3) -> Result<(), ResultCode> {
     management::register(db)


### PR DESCRIPTION
When the SDK passes a JSON-serialized schema to the core extension, that schema is mostly traversed using JSON functions in SQL. IMO, some of these are rather tricky to understand and enforce more complexity (e.g. with the streaming iterators to `json_object_fragment`) than necessary.

This refactors some of the queries to parse the schema using serde instead, which in some cases allows traversing it much easier. All the existing golden schema test pass, so this doesn't change behavior. Some of the queries which only need a subset of information from the schema are left unchanged for now.