### PR TITLE
Update Rust toolchain

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Setup
         run: |
-          rustup toolchain install nightly-2024-05-18-x86_64-unknown-linux-gnu
-          rustup component add rust-src --toolchain nightly-2024-05-18-x86_64-unknown-linux-gnu
+          rustup toolchain install nightly-2025-04-15-x86_64-unknown-linux-gnu
+          rustup component add rust-src --toolchain nightly-2025-04-15-x86_64-unknown-linux-gnu
           rustup target add \
             aarch64-linux-android \
             armv7-linux-androideabi \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -14,8 +14,8 @@ jobs:
 
       - name: Setup
         run: |
-          rustup toolchain install nightly-2024-05-18-aarch64-apple-darwin
-          rustup component add rust-src --toolchain nightly-2024-05-18-aarch64-apple-darwin
+          rustup toolchain install nightly-2025-04-15-aarch64-apple-darwin
+          rustup component add rust-src --toolchain nightly-2025-04-15-aarch64-apple-darwin
           rustup target add \
             x86_64-apple-darwin \
             aarch64-apple-darwin \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2024-05-18
+          toolchain: nightly-2025-04-15
           components: rust-src
 
       - name: Build binaries
@@ -33,7 +33,7 @@ jobs:
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2024-05-18
+          toolchain: nightly-2025-04-15
           components: rust-src
 
       - name: Build binaries

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2024-05-18
+          toolchain: nightly-2025-04-15
           components: rust-src
 
       - name: Build binary
@@ -33,7 +33,7 @@ jobs:
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2024-05-18
+          toolchain: nightly-2025-04-15
           components: rust-src
 
       - name: Build binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,8 @@ jobs:
 
       - name: Setup
         run: |
-          rustup toolchain install nightly-2024-05-18-x86_64-unknown-linux-gnu
-          rustup component add rust-src --toolchain nightly-2024-05-18-x86_64-unknown-linux-gnu
+          rustup toolchain install nightly-2025-04-15-x86_64-unknown-linux-gnu
+          rustup component add rust-src --toolchain nightly-2025-04-15-x86_64-unknown-linux-gnu
           rustup target add \
             aarch64-linux-android \
             armv7-linux-androideabi \
@@ -84,8 +84,8 @@ jobs:
 
       - name: Setup
         run: |
-          rustup toolchain install nightly-2024-05-18-aarch64-apple-darwin
-          rustup component add rust-src --toolchain nightly-2024-05-18-aarch64-apple-darwin
+          rustup toolchain install nightly-2025-04-15-aarch64-apple-darwin
+          rustup component add rust-src --toolchain nightly-2025-04-15-aarch64-apple-darwin
           rustup target add \
             x86_64-apple-darwin \
             aarch64-apple-darwin \
@@ -153,7 +153,7 @@ jobs:
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2024-05-18
+          toolchain: nightly-2025-04-15
           components: rust-src
 
       - name: Build binaries
@@ -178,7 +178,7 @@ jobs:
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2024-05-18
+          toolchain: nightly-2025-04-15
           components: rust-src
 
       - name: Build binaries
@@ -203,7 +203,7 @@ jobs:
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2024-05-18
+          toolchain: nightly-2025-04-15
           components: rust-src
 
       - name: Build binary
@@ -228,7 +228,7 @@ jobs:
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2024-05-18
+          toolchain: nightly-2025-04-15
           components: rust-src
 
       - name: Build binary
@@ -253,7 +253,7 @@ jobs:
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2024-05-18
+          toolchain: nightly-2025-04-15
           components: rust-src
 
       - name: Build binary
@@ -278,7 +278,7 @@ jobs:
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2024-05-18
+          toolchain: nightly-2025-04-15
           components: rust-src
 
       - name: Setup emsdk

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2024-05-18
+          toolchain: nightly-2025-04-15
           components: rust-src
 
       - name: Build

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -8,20 +8,20 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2024-05-18
+          toolchain: nightly-2025-04-15
           components: rust-src
 
       - name: Setup emsdk
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: 3.1.68
+          version: 4.0.7
 
       - name: Build WASM
         run: ./tool/build_wasm.sh

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2024-05-18
+          toolchain: nightly-2025-04-15
           components: rust-src
 
       - name: Build binary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ default-members = ["crates/shell", "crates/sqlite"]
 
 [profile.dev]
 panic = "abort"
-strip = false
 
 [profile.release]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = ["crates/shell", "crates/sqlite"]
 
 [profile.dev]
 panic = "abort"
-strip = true
+strip = false
 
 [profile.release]
 panic = "abort"

--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -1,6 +1,5 @@
 extern crate alloc;
 
-use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::ffi::c_int;

--- a/crates/core/src/diff.rs
+++ b/crates/core/src/diff.rs
@@ -1,6 +1,5 @@
 extern crate alloc;
 
-use alloc::format;
 use alloc::string::{String, ToString};
 use core::ffi::c_int;
 

--- a/crates/core/src/fix_data.rs
+++ b/crates/core/src/fix_data.rs
@@ -117,7 +117,7 @@ fn remove_duplicate_key_encoding(key: &str) -> Option<String> {
 }
 
 fn powersync_remove_duplicate_key_encoding_impl(
-    ctx: *mut sqlite::context,
+    _ctx: *mut sqlite::context,
     args: &[*mut sqlite::value],
 ) -> Result<Option<String>, SQLiteError> {
     let arg = args.get(0).ok_or(ResultCode::MISUSE)?;

--- a/crates/core/src/json_merge.rs
+++ b/crates/core/src/json_merge.rs
@@ -1,6 +1,5 @@
 extern crate alloc;
 
-use alloc::format;
 use alloc::string::{String, ToString};
 use core::ffi::c_int;
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,7 +2,6 @@
 #![feature(vec_into_raw_parts)]
 #![allow(internal_features)]
 #![feature(core_intrinsics)]
-#![feature(error_in_core)]
 #![feature(assert_matches)]
 
 extern crate alloc;

--- a/crates/core/src/uuid.rs
+++ b/crates/core/src/uuid.rs
@@ -1,6 +1,5 @@
 extern crate alloc;
 
-use alloc::format;
 use alloc::string::String;
 use alloc::string::ToString;
 use core::ffi::c_int;

--- a/crates/loadable/src/lib.rs
+++ b/crates/loadable/src/lib.rs
@@ -3,7 +3,6 @@
 #![feature(core_intrinsics)]
 #![allow(internal_features)]
 #![feature(lang_items)]
-#![feature(error_in_core)]
 
 extern crate alloc;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-05-18"
+channel = "nightly-2025-04-15"

--- a/tool/build_wasm.sh
+++ b/tool/build_wasm.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+emcc --version
 
 # Normal build
 # target/wasm32-unknown-emscripten/wasm/powersync.wasm
@@ -31,13 +32,13 @@ cp "target/wasm32-unknown-emscripten/wasm_asyncify/powersync.wasm" "libpowersync
 # Static lib.
 # Works for both sync and asyncify builds.
 # Works for both emscripten and wasi.
-# target/wasm32-wasi/wasm/libpowersync.a
+# target/wasm32-wasip1/wasm/libpowersync.a
 cargo build \
   -p powersync_loadable \
   --profile wasm \
   --no-default-features \
   --features "powersync_core/static powersync_core/omit_load_extension sqlite_nostd/omit_load_extension" \
   -Z build-std=panic_abort,core,alloc \
-  --target wasm32-wasi
+  --target wasm32-wasip1
 
-cp "target/wasm32-wasi/wasm/libpowersync.a" "libpowersync-wasm.a"
+cp "target/wasm32-wasip1/wasm/libpowersync.a" "libpowersync-wasm.a"


### PR DESCRIPTION
This updates to a rustc nightly version that is more recent (`2024-05-18` to `2025-04-15`). https://github.com/powersync-ja/powersync-sqlite-core/pull/70 relies on features that have been added more recently.

This also fixes some compilation warnings, mainly about unused imports or parameters.