### PR TITLE
Avoid allocation in deserialize to i64

### DIFF
--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -61,6 +61,7 @@ where
         }
     }
 
+    // Using a custom visitor here to avoid an intermediate string allocation
     deserializer.deserialize_str(ValueVisitor)
 }
 
@@ -92,7 +93,6 @@ where
         }
     }
 
-    // Using a custom visitor here to avoid an intermediate string allocation
     deserializer.deserialize_option(ValueVisitor)
 }
 

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -50,7 +50,7 @@ where
         type Value = i64;
 
         fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
-            formatter.write_str("a string")
+            formatter.write_str("a string representation of a number")
         }
 
         fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>


### PR DESCRIPTION
This is another item taken out of https://github.com/powersync-ja/powersync-sqlite-core/pull/70.

The current implementation of `deserialize_string_to_i64` first deserializes a JSON value to a `String` before attempting to parse it as an `i64` value. This requires an intermediate allocation for the string value because it's owned by `deserialize_string_to_i64`. Calling `str::parse` works on a reference too though, so writing a proper serde visitor with the ability to handle ephemeral strings improves performance slightly. It also ensures that the method works for non-JSON deserializers (such as BSON).