### PR TITLE
Update version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "powersync_core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bytes",
  "const_format",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "cc",
  "powersync_core",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_static"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -388,7 +388,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "sqlite3"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 inherits = "wasm"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@ Bump the version number in these places:
 2. powersync-sqlite-core.podspec.
 3. android/build.gradle.kts
 4. android/src/prefab/prefab.json
-5. tool/build_xcframework.sh - CFBundleVersion and CFBundleShortVersionString.
+5. tool/build_xcframework.sh - `VERSION` variable.
 6. `cargo build` to update Cargo.lock
 
 Create a tag:

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "co.powersync"
-version = "0.4.0"
+version = "0.4.1"
 description = "PowerSync Core SQLite Extension"
 
 repositories {

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.4.0"
+  "version": "0.4.1"
 }

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.4.0'
+  s.version          = '0.4.1'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -20,7 +20,7 @@ TARGETS=(
   x86_64-apple-watchos-sim
   arm64_32-apple-watchos
 )
-VERSION=0.4.0
+VERSION=0.4.1
 
 function generatePlist() {
   min_os_version=0


### PR DESCRIPTION
This prepares a minor release of the core extension. Changes are the simpler crud vtab addition, watchOS support, and initial experimental support for syncing into user-controlled "raw" tables.