### PR TITLE
Allow static strings in `SQLiteError`

### DIFF
--- a/crates/core/src/crud_vtab.rs
+++ b/crates/core/src/crud_vtab.rs
@@ -1,7 +1,6 @@
 extern crate alloc;
 
 use alloc::boxed::Box;
-use alloc::string::String;
 use alloc::sync::Arc;
 use const_format::formatcp;
 use core::ffi::{c_char, c_int, c_void, CStr};
@@ -86,7 +85,7 @@ impl VirtualTable {
         let current_tx = self
             .current_tx
             .as_mut()
-            .ok_or_else(|| SQLiteError(ResultCode::MISUSE, Some(String::from("No tx_id"))))?;
+            .ok_or_else(|| SQLiteError::misuse("No tx_id"))?;
         let db = self.db;
 
         if self.state.is_in_sync_local.load(Ordering::Relaxed) {

--- a/crates/core/src/kv.rs
+++ b/crates/core/src/kv.rs
@@ -1,6 +1,5 @@
 extern crate alloc;
 
-use alloc::format;
 use alloc::string::{String, ToString};
 use core::ffi::c_int;
 
@@ -30,9 +29,9 @@ pub fn client_id(db: *mut sqlite::sqlite3) -> Result<String, SQLiteError> {
         let client_id = statement.column_text(0)?;
         Ok(client_id.to_string())
     } else {
-        Err(SQLiteError(
+        Err(SQLiteError::with_description(
             ResultCode::ABORT,
-            Some(format!("No client_id found in ps_kv")),
+            "No client_id found in ps_kv",
         ))
     }
 }

--- a/crates/core/src/migrations.rs
+++ b/crates/core/src/migrations.rs
@@ -55,16 +55,16 @@ CREATE TABLE IF NOT EXISTS ps_migration(id INTEGER PRIMARY KEY, down_migrations 
         for sql in down_sql {
             let rs = local_db.exec_safe(&sql);
             if let Err(code) = rs {
-                return Err(SQLiteError(
+                return Err(SQLiteError::with_description(
                     code,
-                    Some(format!(
+                    format!(
                         "Down migration failed for {:} {:} {:}",
                         current_version,
                         sql,
                         local_db
                             .errmsg()
                             .unwrap_or(String::from("Conversion error"))
-                    )),
+                    ),
                 ));
             }
         }
@@ -73,20 +73,20 @@ CREATE TABLE IF NOT EXISTS ps_migration(id INTEGER PRIMARY KEY, down_migrations 
         current_version_stmt.reset()?;
         let rc = current_version_stmt.step()?;
         if rc != ResultCode::ROW {
-            return Err(SQLiteError(
+            return Err(SQLiteError::with_description(
                 rc,
-                Some("Down migration failed - could not get version".to_string()),
+                "Down migration failed - could not get version",
             ));
         }
         let new_version = current_version_stmt.column_int(0);
         if new_version >= current_version {
             // Database down from version $currentVersion to $version failed - version not updated after dow migration
-            return Err(SQLiteError(
+            return Err(SQLiteError::with_description(
                 ResultCode::ABORT,
-                Some(format!(
+                format!(
                     "Down migration failed - version not updated from {:}",
                     current_version
-                )),
+                ),
             ));
         }
         current_version = new_version;

--- a/crates/core/src/sync/interface.rs
+++ b/crates/core/src/sync/interface.rs
@@ -4,7 +4,6 @@ use core::ffi::{c_int, c_void};
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::rc::Rc;
-use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::{string::String, vec::Vec};
 use serde::{Deserialize, Serialize};
@@ -141,10 +140,7 @@ pub fn register(db: *mut sqlite::sqlite3, state: Arc<DatabaseState>) -> Result<(
             };
 
             if op.value_type() != ColumnType::Text {
-                return Err(SQLiteError(
-                    ResultCode::MISUSE,
-                    Some("First argument must be a string".to_string()),
-                ));
+                return Err(SQLiteError::misuse("First argument must be a string"));
             }
 
             let op = op.text();
@@ -161,29 +157,20 @@ pub fn register(db: *mut sqlite::sqlite3, state: Arc<DatabaseState>) -> Result<(
                     data: if payload.value_type() == ColumnType::Text {
                         payload.text()
                     } else {
-                        return Err(SQLiteError(
-                            ResultCode::MISUSE,
-                            Some("Second argument must be a string".to_string()),
-                        ));
+                        return Err(SQLiteError::misuse("Second argument must be a string"));
                     },
                 }),
                 "line_binary" => SyncControlRequest::SyncEvent(SyncEvent::BinaryLine {
                     data: if payload.value_type() == ColumnType::Blob {
                         payload.blob()
                     } else {
-                        return Err(SQLiteError(
-                            ResultCode::MISUSE,
-                            Some("Second argument must be a byte array".to_string()),
-                        ));
+                        return Err(SQLiteError::misuse("Second argument must be a byte array"));
                     },
                 }),
                 "refreshed_token" => SyncControlRequest::SyncEvent(SyncEvent::DidRefreshToken),
                 "completed_upload" => SyncControlRequest::SyncEvent(SyncEvent::UploadFinished),
                 _ => {
-                    return Err(SQLiteError(
-                        ResultCode::MISUSE,
-                        Some("Unknown operation".to_string()),
-                    ))
+                    return Err(SQLiteError::misuse("Unknown operation"));
                 }
             };
 

--- a/crates/core/src/sync/streaming_sync.rs
+++ b/crates/core/src/sync/streaming_sync.rs
@@ -71,10 +71,7 @@ impl SyncClient {
                 let mut active = ActiveEvent::new(sync_event);
 
                 let ClientState::IterationActive(handle) = &mut self.state else {
-                    return Err(SQLiteError(
-                        ResultCode::MISUSE,
-                        Some("No iteration is active".to_string()),
-                    ));
+                    return Err(SQLiteError::misuse("No iteration is active"));
                 };
 
                 match handle.run(&mut active) {
@@ -308,11 +305,9 @@ impl StreamingSyncIteration {
                 }
                 SyncLine::CheckpointDiff(diff) => {
                     let Some(target) = target.target_checkpoint_mut() else {
-                        return Err(SQLiteError(
+                        return Err(SQLiteError::with_description(
                             ResultCode::ABORT,
-                            Some(
-                                "Received checkpoint_diff without previous checkpoint".to_string(),
-                            ),
+                            "Received checkpoint_diff without previous checkpoint",
                         ));
                     };
 
@@ -329,12 +324,9 @@ impl StreamingSyncIteration {
                 }
                 SyncLine::CheckpointComplete(_) => {
                     let Some(target) = target.target_checkpoint_mut() else {
-                        return Err(SQLiteError(
+                        return Err(SQLiteError::with_description(
                             ResultCode::ABORT,
-                            Some(
-                                "Received checkpoint complete without previous checkpoint"
-                                    .to_string(),
-                            ),
+                            "Received checkpoint complete without previous checkpoint",
                         ));
                     };
                     let result =
@@ -374,12 +366,9 @@ impl StreamingSyncIteration {
                 SyncLine::CheckpointPartiallyComplete(complete) => {
                     let priority = complete.priority;
                     let Some(target) = target.target_checkpoint_mut() else {
-                        return Err(SQLiteError(
+                        return Err(SQLiteError::with_description(
                             ResultCode::ABORT,
-                            Some(
-                                "Received checkpoint complete without previous checkpoint"
-                                    .to_string(),
-                            ),
+                            "Received checkpoint complete without previous checkpoint",
                         ));
                     };
                     let result = self.adapter.sync_local(


### PR DESCRIPTION
This refactors the `SQLiteError` struct to allow both dynamically-allocated strings and `&'static str`, making them easier to create from string literals.