### PR TITLE
WIP: Recover from some errors within sync iteration

### DIFF
--- a/crates/core/src/sync/streaming_sync.rs
+++ b/crates/core/src/sync/streaming_sync.rs
@@ -462,7 +462,9 @@ impl StreamingSyncIteration {
                         ()
                     }
                 }
-                Err(e) if e.can_retry() => {}
+                Err(e) if e.can_retry() => {
+                    event.recoverable_error = Some(e);
+                }
                 Err(e) => return Err(e),
             };
 


### PR DESCRIPTION
This adds the `can_retry` method to the new `PowerSyncError` type (#96). Then, in the sync iteration, we catch errors for each sync line and check whether the error is fatal or whether we allow retrying the operation.

When retrying isn't necessary, we keep the sync iteration future active. `powersync_control` will still return an error, but the invocation can be retried after e.g. unlocking a database or waiting for a WA-sqlite VFS to settle.