### PR TITLE
Ignore unknown sync lines

### DIFF
--- a/crates/core/src/sync/streaming_sync.rs
+++ b/crates/core/src/sync/streaming_sync.rs
@@ -398,6 +398,13 @@ impl StreamingSyncIteration {
                     SyncStateMachineTransition::Empty
                 }
             }
+            SyncLine::UnknownSyncLine => {
+                event.instructions.push(Instruction::LogLine {
+                    severity: LogSeverity::DEBUG,
+                    line: "Unknown sync line".into(),
+                });
+                SyncStateMachineTransition::Empty
+            }
         })
     }
 


### PR DESCRIPTION
When receiving a sync line they don't understand, the behavior in our existing client implementations was to ignore it. We also assume this behavior when extending the sync protocol. For example, it has been useful when introducing partial checkpoint messages for priotized sync.

However, the behavior in the Rust decoding logic was to throw an error on unknown keys. This fixes the logic to decode sync lines so that unknown lines can get ignored.