### PR TITLE
Build with NDK 28 or newer for 16KB page alignment

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -30,7 +30,6 @@ jobs:
             x86_64-linux-android \
             i686-linux-android
           cargo install cargo-ndk
-          cargo ndk-env
 
       - name: Build for Android
         run: |

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,11 +8,11 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "17"
@@ -30,6 +30,7 @@ jobs:
             x86_64-linux-android \
             i686-linux-android
           cargo install cargo-ndk
+          cargo ndk-env
 
       - name: Build for Android
         run: |

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -36,3 +36,10 @@ jobs:
           cd android
           ./gradlew build
           ls -lh build/outputs/aar
+
+      - name: Upload Android library
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-library
+          path: |
+            android/build/outputs/aar/

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -22,13 +22,21 @@ repositories {
 }
 
 fun ndkPath(): String {
-    val properties = Properties()
-    properties.load(project.rootProject.file("local.properties").inputStream())
+    val file = project.rootProject.file("local.properties")
+    var androidHome = System.getenv("ANDROID_HOME")
 
-    val androidHome = properties["sdk.dir"] ?: System.getenv("ANDROID_HOME")
+    if (file.exists()) {
+        val properties = Properties()
+        properties.load(project.rootProject.file("local.properties").inputStream())
+
+        properties["sdk.dir"]?.let {
+            androidHome = it as String
+        }
+    }
+
     check(androidHome != null) { "Could not find android SDK dir" }
 
-    val ndks = Path(androidHome.toString()).resolve("ndk")
+    val ndks = Path(androidHome).resolve("ndk")
     check(ndks.exists()) { "Expected NDK installations at $ndks" }
 
     for (entry in ndks.listDirectoryEntries()) {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,4 +1,11 @@
+import org.gradle.tooling.BuildException
 import java.util.Base64
+import java.util.Properties
+import kotlin.io.path.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.exists
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.name
 
 plugins {
     id("maven-publish")
@@ -14,7 +21,33 @@ repositories {
     google()
 }
 
+fun ndkPath(): String {
+    val properties = Properties()
+    properties.load(project.rootProject.file("local.properties").inputStream())
+
+    val androidHome = properties["sdk.dir"] ?: System.getenv("ANDROID_HOME")
+    check(androidHome != null) { "Could not find android SDK dir" }
+
+    val ndks = Path(androidHome.toString()).resolve("ndk")
+    check(ndks.exists()) { "Expected NDK installations at $ndks" }
+
+    for (entry in ndks.listDirectoryEntries()) {
+        val name = entry.name
+        val majorVersion = name.split('.').first().toInt()
+
+        // We want to use NDK 28 or newer to build with 16KB support by default.
+        if (majorVersion >= 28) {
+            return entry.absolutePathString()
+        }
+    }
+
+    error("Expected an NDK 28 or later installation in $ndks")
+}
+
 val buildRust = tasks.register<Exec>("buildRust") {
+    group = "build"
+    environment("ANDROID_NDK_HOME", ndkPath())
+
     workingDir("..")
     commandLine(
         "cargo",

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Starting [this November](https://developer.android.com/guide/practices/page-sizes), virtually all Android apps are required to support running with 16KB page sizes enabled.

At the moment, the library we build for Android is 4KB-aligned. 

```
$ ~/Library/Android/sdk/ndk/28.1.13356709/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-objdump -p libpowersync.so | grep LOAD
    LOAD off    0x0000000000000000 vaddr 0x0000000000000000 paddr 0x0000000000000000 align 2**12
    LOAD off    0x000000000001c78c vaddr 0x000000000001d78c paddr 0x000000000001d78c align 2**12
    LOAD off    0x0000000000050c00 vaddr 0x0000000000052c00 paddr 0x0000000000052c00 align 2**12
    LOAD off    0x0000000000052698 vaddr 0x0000000000055698 paddr 0x0000000000055698 align 2**12
```

When using cargo-ndk with NDK 28 or above, it generates 16KB-aligned libraries by default:

```
$ ~/Library/Android/sdk/ndk/28.1.13356709/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-objdump -p build/intermediates/jniLibs/arm64-v8a/libpowersync.so | grep LOAD
    LOAD off    0x0000000000000000 vaddr 0x0000000000000000 paddr 0x0000000000000000 align 2**14
    LOAD off    0x000000000001d004 vaddr 0x0000000000021004 paddr 0x0000000000021004 align 2**14
    LOAD off    0x0000000000050f10 vaddr 0x0000000000058f10 paddr 0x0000000000058f10 align 2**14
    LOAD off    0x00000000000529e8 vaddr 0x000000000005e9e8 paddr 0x000000000005e9e8 align 2**14
```

This can also be achieved with a linker option we could set in cargo, but updating the NDK and then relying on the default options sounds easier.

I've validated these changes by running a Flutter demo app on a 16KB emulator.