### PR TITLE
Prepare 0.4.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "powersync_core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bytes",
  "const_format",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "cc",
  "powersync_core",
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_static"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -389,7 +389,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "sqlite3"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 inherits = "wasm"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "com.powersync"
-version = "0.4.1"
+version = "0.4.2"
 description = "PowerSync Core SQLite Extension"
 
 val localRepo = uri("build/repository/")

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.4.1"
+  "version": "0.4.2"
 }

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.4.1'
+  s.version          = '0.4.2'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -20,7 +20,7 @@ TARGETS=(
   x86_64-apple-watchos-sim
   arm64_32-apple-watchos
 )
-VERSION=0.4.1
+VERSION=0.4.2
 
 function generatePlist() {
   min_os_version=0


### PR DESCRIPTION
This updates the version of the core extension to `0.4.2`, preparing a patch release with these changes:

1. Refactor the internal error handling to use structured error types.
2. Refactor the sync client to allow retrying for underlying SQLite errors.
3. Update the NDK build to use 16KB-aligned ELF segments.
