### PR TITLE
Avoid nested JSON elements in ps_crud

### DIFF
--- a/crates/core/src/schema/mod.rs
+++ b/crates/core/src/schema/mod.rs
@@ -6,7 +6,8 @@ use serde::Deserialize;
 use sqlite::ResultCode;
 use sqlite_nostd as sqlite;
 pub use table_info::{
-    DiffIncludeOld, PendingStatement, PendingStatementValue, RawTable, Table, TableInfoFlags,
+    Column, DiffIncludeOld, PendingStatement, PendingStatementValue, RawTable, Table,
+    TableInfoFlags,
 };
 
 #[derive(Deserialize, Default)]

--- a/crates/core/src/schema/table_info.rs
+++ b/crates/core/src/schema/table_info.rs
@@ -45,8 +45,21 @@ impl Table {
         }
     }
 
-    pub fn column_names(&self) -> impl Iterator<Item = &str> {
-        self.columns.iter().map(|c| c.name.as_str())
+    pub fn filtered_columns<'a>(
+        &'a self,
+        names: impl Iterator<Item = &'a str>,
+    ) -> impl Iterator<Item = &'a Column> {
+        // First, sort all columns by name for faster lookups by name.
+        let mut sorted_by_name: Vec<&Column> = self.columns.iter().collect();
+        sorted_by_name.sort_by_key(|c| &*c.name);
+
+        names.filter_map(move |name| {
+            let index = sorted_by_name
+                .binary_search_by_key(&name, |c| c.name.as_str())
+                .ok()?;
+
+            Some(sorted_by_name[index])
+        })
     }
 }
 

--- a/dart/test/crud_test.dart
+++ b/dart/test/crud_test.dart
@@ -661,5 +661,25 @@ void main() {
       // The update which didn't change any rows should not be recorded.
       expect(db.select('SELECT * FROM ps_crud'), hasLength(1));
     });
+
+    test('json values are included as text', () {
+      db
+        ..execute('select powersync_replace_schema(?)', [
+          json.encode({
+            'tables': [
+              {
+                'name': 'items',
+                'columns': [
+                  {'name': 'col', 'type': 'text'}
+                ],
+              }
+            ]
+          })
+        ])
+        ..execute('INSERT INTO items (id, col) VALUES (uuid(), json_object())');
+
+      final [update] = db.select('SELECT data FROM ps_crud');
+      expect(json.decode(update['data']), containsPair('data', {'col': '{}'}));
+    });
   });
 }

--- a/dart/test/utils/migration_fixtures.dart
+++ b/dart/test/utils/migration_fixtures.dart
@@ -536,8 +536,8 @@ END
       THEN RAISE (FAIL, 'id should be text')
       END;
       INSERT INTO "ps_data__lists"
-      SELECT NEW.id, json_object('description', NEW."description");
-      INSERT INTO powersync_crud_(data) VALUES(json_object('op', 'PUT', 'type', 'lists', 'id', NEW.id, 'data', json(powersync_diff('{}', json_object('description', NEW."description")))));
+      SELECT NEW.id, json_object('description', concat(NEW."description"));
+      INSERT INTO powersync_crud_(data) VALUES(json_object('op', 'PUT', 'type', 'lists', 'id', NEW.id, 'data', json(powersync_diff('{}', json_object('description', concat(NEW."description"))))));
       INSERT INTO ps_oplog(bucket, op_id, op, row_type, row_id, hash, superseded)
       SELECT '$local',
               1,
@@ -557,9 +557,9 @@ BEGIN
   THEN RAISE (FAIL, 'Cannot update id')
   END;
   UPDATE "ps_data__lists"
-      SET data = json_object('description', NEW."description")
+      SET data = json_object('description', concat(NEW."description"))
       WHERE id = NEW.id;
-  INSERT INTO powersync_crud_(data) VALUES(json_object('op', 'PATCH', 'type', 'lists', 'id', NEW.id, 'data', json(powersync_diff(json_object('description', OLD."description"), json_object('description', NEW."description")))));
+  INSERT INTO powersync_crud_(data) VALUES(json_object('op', 'PATCH', 'type', 'lists', 'id', NEW.id, 'data', json(powersync_diff(json_object('description', concat(OLD."description")), json_object('description', concat(NEW."description"))))));
   INSERT INTO ps_oplog(bucket, op_id, op, row_type, row_id, hash, superseded)
   SELECT '$local',
           1,
@@ -598,8 +598,8 @@ END
       WHEN (typeof(NEW.id) != 'text')
       THEN RAISE (FAIL, 'id should be text')
       END;
-      INSERT INTO "ps_data__lists" SELECT NEW.id, json_object('description', NEW."description");
-      INSERT INTO powersync_crud(op,id,type,data) VALUES ('PUT',NEW.id,'lists',json(powersync_diff('{}', json_object('description', NEW."description"))));
+      INSERT INTO "ps_data__lists" SELECT NEW.id, json_object('description', concat(NEW."description"));
+      INSERT INTO powersync_crud(op,id,type,data) VALUES ('PUT',NEW.id,'lists',json(powersync_diff('{}', json_object('description', concat(NEW."description")))));
     END
 ;CREATE TRIGGER "ps_view_update_lists"
 INSTEAD OF UPDATE ON "lists"
@@ -610,9 +610,9 @@ BEGIN
   THEN RAISE (FAIL, 'Cannot update id')
   END;
   UPDATE "ps_data__lists"
-      SET data = json_object('description', NEW."description")
+      SET data = json_object('description', concat(NEW."description"))
       WHERE id = NEW.id;
-  INSERT INTO powersync_crud(op,type,id,data,options) VALUES ('PATCH','lists',NEW.id,json(powersync_diff(json_object('description', OLD."description"), json_object('description', NEW."description"))),0);
+  INSERT INTO powersync_crud(op,type,id,data,options) VALUES ('PATCH','lists',NEW.id,json(powersync_diff(json_object('description', concat(OLD."description")), json_object('description', concat(NEW."description")))),0);
 END
 ''';
 
@@ -636,8 +636,8 @@ END
       WHEN (typeof(NEW.id) != 'text')
       THEN RAISE (FAIL, 'id should be text')
       END;
-      INSERT INTO "ps_data__lists" SELECT NEW.id, json_object('description', NEW."description");
-      INSERT INTO powersync_crud(op,id,type,data) VALUES ('PUT',NEW.id,'lists',json(powersync_diff('{}', json_object('description', NEW."description"))));
+      INSERT INTO "ps_data__lists" SELECT NEW.id, json_object('description', concat(NEW."description"));
+      INSERT INTO powersync_crud(op,id,type,data) VALUES ('PUT',NEW.id,'lists',json(powersync_diff('{}', json_object('description', concat(NEW."description")))));
     END
 ;CREATE TRIGGER "ps_view_update_lists"
 INSTEAD OF UPDATE ON "lists"
@@ -648,8 +648,8 @@ BEGIN
   THEN RAISE (FAIL, 'Cannot update id')
   END;
   UPDATE "ps_data__lists"
-      SET data = json_object('description', NEW."description")
+      SET data = json_object('description', concat(NEW."description"))
       WHERE id = NEW.id;
-  INSERT INTO powersync_crud(op,type,id,data,options) VALUES ('PATCH','lists',NEW.id,json(powersync_diff(json_object('description', OLD."description"), json_object('description', NEW."description"))),0);
+  INSERT INTO powersync_crud(op,type,id,data,options) VALUES ('PATCH','lists',NEW.id,json(powersync_diff(json_object('description', concat(OLD."description")), json_object('description', concat(NEW."description")))),0);
 END
 ''';


### PR DESCRIPTION
To collect local writes, we use `json_object()` to combine column values into a CRUD entry. A problem with this is that, if one of the columns has a JSON subtype, `json_object()` writes it as a nested object instead of a string. Following [this suggestion](https://www.sqlite.org/forum/forumpost/57ed0b1feb30bd01), we wrap text column types in a single-argument `concat` call to drop the subtype.

I have not yet checked the performance impact of this. Another approach that unfortunately occurred too late to me may be to re-implement `json_object` in PowerSync, avoiding the nested behavior we don't need. That could potentially be faster.