### PR TITLE
Fix release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
 jobs:
   draft_release:
-    if: github.event_name == 'workflow_dispatch'
     name: Create Draft GitHub Release
     runs-on: ubuntu-latest
     outputs:
@@ -47,7 +46,7 @@ jobs:
       contents: read
       packages: write
     name: Publish Android
-    needs: [draft_release, build_android]
+    needs: [ draft_release, build_android ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +73,7 @@ jobs:
 
   publish_ios_pod_and_spm_package:
     name: Publish iOS
-    needs: [draft_release]
+    needs: [ draft_release ]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -142,7 +141,7 @@ jobs:
 
   publish_linux_x86_64:
     name: Publish Linux x86_64
-    needs: [draft_release]
+    needs: [ draft_release ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -167,7 +166,7 @@ jobs:
 
   publish_linux_aarch64:
     name: Publish Linux aarch64
-    needs: [draft_release]
+    needs: [ draft_release ]
     runs-on: ubuntu-arm64
     steps:
       - uses: actions/checkout@v3
@@ -192,7 +191,7 @@ jobs:
 
   publish_windows_x64:
     name: Publish Windows x64
-    needs: [draft_release]
+    needs: [ draft_release ]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
@@ -217,7 +216,7 @@ jobs:
 
   publish_macOS_aarch64:
     name: Publish macOS aarch64
-    needs: [draft_release]
+    needs: [ draft_release ]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -242,7 +241,7 @@ jobs:
 
   publish_macOS_x64:
     name: Publish macOS x64
-    needs: [draft_release]
+    needs: [ draft_release ]
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v3
@@ -267,7 +266,7 @@ jobs:
 
   publish_wasm:
     name: Publish WASM builds
-    needs: [draft_release]
+    needs: [ draft_release ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -333,7 +332,7 @@ jobs:
             --body "$BODY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}          
+          GH_REPO: ${{ github.repository }}
           TITLE: "Release checklist: ${{ needs.draft_release.outputs.tag }}"
           ASSIGNES: ${{ github.event.push.sender }}
           BODY: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Primarily, this removes the `github.event_name == 'workflow_dispatch'` condition left in the `draft_release` job.

I've tagged the first commit in this PR to trigger the release. That worked, except that the Android build could not be attached to the release for some reason (it was uploaded to central though). That may have been due to `depth: 0` in that checkout step, I guess we'll find out with the next release. That attachment is only used for debug purposes anyway.