### PR TITLE
Don't attach Android bundle to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,13 +62,6 @@ jobs:
             --form bundle=@powersync_android.zip \
             'https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC'
 
-      - name: Upload binary
-        uses: ./.github/actions/upload
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          file-name: powersync_android.zip
-          tag: ${{ needs.draft_release.outputs.tag }}
-
   publish_ios_pod_and_spm_package:
     name: Publish iOS
     needs: [ draft_release ]


### PR DESCRIPTION
For some reason that step always fails with "release not found". I don't know why, maybe spelling the permissions out explicitly for that job causes the token to not see draft releases? Whatever, we don't need that attachment anyway. This removes the step entirely.