### PR TITLE
Document why binary data is set

### DIFF
--- a/crates/core/src/sync/streaming_sync.rs
+++ b/crates/core/src/sync/streaming_sync.rs
@@ -589,6 +589,9 @@ impl StreamingSyncIteration {
             buckets: requests,
             include_checksum: true,
             raw_data: true,
+            // Clients are not supposed to set this field, but old versions of the PowerSync service
+            // will break if it's not set and the SDK requests sync data as BSON.
+            // For details, see https://github.com/powersync-ja/powersync-service/pull/332
             binary_data: true,
             client_id: client_id(self.db)?,
             parameters: self.options.parameters.take(),


### PR DESCRIPTION
We're about to remove the `binary_data` field from the protocol. No other SDK sets that field and the field is supposed to be service-internal. Nothing breaks when it's set, but not setting it breaks older PowerSync services.

So, we will continue to set it in the Rust client, but that deserves a little comment explaining why.