### PR TITLE
Fix release actions

### DIFF
--- a/.github/actions/xcframework/action.yml
+++ b/.github/actions/xcframework/action.yml
@@ -40,6 +40,6 @@ runs:
       with:
         name: xcframework
         retention-days: 14
-        compression: 0 # We're uploading a zip archive, no need to compress agan
+        compression-level: 0 # We're uploading a zip archive, no need to compress agan
         path: |
           powersync-sqlite-core.xcframework.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@ on:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
-    branches:
-      - fix-release-ci
-
 jobs:
   draft_release:
     name: Create Draft GitHub Release
@@ -20,9 +17,9 @@ jobs:
       - name: Set tag name
         id: tag
         run: |
-          echo "tag=v0.4.5" >> $GITHUB_OUTPUT
+          tag=$(basename "${{ github.ref }}")
+          echo "tag=$tag" >> $GITHUB_OUTPUT
       - name: Create Release
-        if: false
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -63,7 +60,6 @@ jobs:
 
   libs_android:
     name: Building Android libraries
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -77,7 +73,6 @@ jobs:
 
   libs_wasm:
     name: Basic WASM build
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -102,7 +97,6 @@ jobs:
       contents: read
       packages: write
     name: Publish Android
-    if: false
     needs: [ draft_release, libs_android ]
     runs-on: ubuntu-latest
     steps:
@@ -211,7 +205,6 @@ jobs:
           gh release upload "${{ needs.draft_release.outputs.tag }}" *.so
 
   publish_wasm:
-    if: false
     name: Publish WASM builds
     needs: [ draft_release, libs_wasm ]
     runs-on: ubuntu-latest
@@ -253,8 +246,10 @@ jobs:
     runs-on: macos-latest
     needs:
       - draft_release
+      - publish_android
       - publish_ios_pod_and_spm_package
       - publish_desktop
+      - publish_wasm
     steps:
       - name: Create issue
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
+    branches:
+      - fix-release-ci
+
 jobs:
   draft_release:
     name: Create Draft GitHub Release
@@ -17,9 +20,9 @@ jobs:
       - name: Set tag name
         id: tag
         run: |
-          tag=$(basename "${{ github.ref }}")
-          echo "tag=$tag" >> $GITHUB_OUTPUT
+          echo "tag=v0.4.5" >> $GITHUB_OUTPUT
       - name: Create Release
+        if: false
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -30,18 +33,16 @@ jobs:
 
   libs_linux:
     name: Building Linux libraries
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)  
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Build Android
+      - name: Build Linux
         uses: ./.github/actions/linux
 
   libs_macos:
     name: Building macOS libraries
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)  
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -52,7 +53,6 @@ jobs:
 
   libs_windows:
     name: Building Windows libraries
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)  
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
 
   libs_android:
     name: Building Android libraries
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -77,7 +77,7 @@ jobs:
 
   libs_wasm:
     name: Basic WASM build
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -89,7 +89,6 @@ jobs:
 
   libs_xcframework:
     name: Build XCFramework
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -103,6 +102,7 @@ jobs:
       contents: read
       packages: write
     name: Publish Android
+    if: false
     needs: [ draft_release, libs_android ]
     runs-on: ubuntu-latest
     steps:
@@ -132,6 +132,9 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           name: xcframework
+
+      - name: Extract xcframework
+        run: unzip powersync-sqlite-core.xcframework.zip "powersync-sqlite-core.xcframework/*"
 
       - name: Lint pod
         run: |
@@ -186,17 +189,17 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           name: linux-library
-          path: dart/assets
       - name: Download libs
         uses: actions/download-artifact@v5
         with:
           name: macos-library
-          path: dart/assets
       - name: Download libs
         uses: actions/download-artifact@v5
         with:
           name: windows-library
-          path: dart/assets
+
+      - name: List libraries
+        run: ls -al
 
       - name: Upload binary
         env:
@@ -208,6 +211,7 @@ jobs:
           gh release upload "${{ needs.draft_release.outputs.tag }}" *.so
 
   publish_wasm:
+    if: false
     name: Publish WASM builds
     needs: [ draft_release, libs_wasm ]
     runs-on: ubuntu-latest
@@ -249,10 +253,8 @@ jobs:
     runs-on: macos-latest
     needs:
       - draft_release
-      - publish_android
       - publish_ios_pod_and_spm_package
       - publish_desktop
-      - publish_wasm
     steps:
       - name: Create issue
         run: |


### PR DESCRIPTION
The original release run for 0.4.5 had a [few issues](https://github.com/powersync-ja/powersync-sqlite-core/actions/runs/17370612158) which I've fixed in this PR. To get that release into a good shape, I re-ran relevant actions with the definitions from 3aaad011f77d382deb9a37bfb9642b8b677e2d06 which have been reverted in a913fcd3cc85bafcebdfe19c1d1ab0c9dca498f2.

Specifically, this PR fixes:

- A warning when uploading the xcframework (`compression` should be `compression-level`).
- A wrong name when compiling Linux libraries
- Unecessary `if`conditions for jobs (the release run is not triggered for PRs, so these checks are not necessary).
- Fixing the target directory we download desktop libraries to before release (should be the root directory instead of the `dart/assets` used for tests).
- Fixing `pod lint` in the SPM release step by extracting the xcframework archive.