### PR TITLE
Delete stream subscriptions on clear

### DIFF
--- a/crates/core/src/view_admin.rs
+++ b/crates/core/src/view_admin.rs
@@ -162,6 +162,7 @@ DELETE FROM ps_untyped;
 DELETE FROM ps_updated_rows;
 DELETE FROM ps_kv WHERE key != 'client_id';
 DELETE FROM ps_sync_state;
+DELETE FROM ps_stream_subscriptions;
 ",
     )?;
 

--- a/dart/test/sync_stream_test.dart
+++ b/dart/test/sync_stream_test.dart
@@ -648,4 +648,18 @@ void main() {
           }
         ]));
   });
+
+  syncTest('clearing database clears subscriptions', (_) {
+    control(
+      'subscriptions',
+      json.encode({
+        'subscribe': {
+          'stream': {'name': 'a'},
+        }
+      }),
+    );
+    expect(db.select('select * from ps_stream_subscriptions'), isNotEmpty);
+    db.execute('select powersync_clear(0);');
+    expect(db.select('select * from ps_stream_subscriptions'), isEmpty);
+  });
 }


### PR DESCRIPTION
This fixes `powersync_clear()` to also delete from `ps_stream_subscriptions`, ensuring that we don't request the same streams again afterwards.