### PR TITLE
Reduce warnings for sync after uploads

### DIFF
--- a/crates/core/src/sync/storage_adapter.rs
+++ b/crates/core/src/sync/storage_adapter.rs
@@ -463,16 +463,12 @@ impl StorageAdapter {
     pub fn local_state(&self) -> Result<Option<LocalState>, PowerSyncError> {
         let stmt = self
             .db
-            .prepare_v2("SELECT target_op, last_op FROM ps_buckets WHERE name = ?")?;
+            .prepare_v2("SELECT target_op FROM ps_buckets WHERE name = ?")?;
         stmt.bind_text(1, "$local", sqlite_nostd::Destructor::STATIC)?;
 
         Ok(if stmt.step()? == ResultCode::ROW {
             let target_op = stmt.column_int64(0);
-            let last_op = stmt.column_int64(1);
-            Some(LocalState {
-                target_op,
-                _last_op: last_op,
-            })
+            Some(LocalState { target_op })
         } else {
             None
         })
@@ -481,7 +477,6 @@ impl StorageAdapter {
 
 pub struct LocalState {
     pub target_op: i64,
-    pub _last_op: i64,
 }
 
 pub struct BucketInfo {

--- a/crates/core/src/sync_local.rs
+++ b/crates/core/src/sync_local.rs
@@ -102,17 +102,10 @@ impl<'a> SyncOperation<'a> {
         if needs_check {
             // language=SQLite
             let statement = self.db.prepare_v2(
-                "\
-    SELECT group_concat(name)
-    FROM ps_buckets
-    WHERE target_op > last_op AND name = '$local'",
+                "SELECT 1 FROM ps_buckets WHERE target_op > last_op AND name = '$local'",
             )?;
 
-            if statement.step()? != ResultCode::ROW {
-                return Err(PowerSyncError::unknown_internal());
-            }
-
-            if statement.column_type(0)? == ColumnType::Text {
+            if statement.step()? == ResultCode::ROW {
                 return Ok(false);
             }
 

--- a/dart/test/utils/test_utils.dart
+++ b/dart/test/utils/test_utils.dart
@@ -11,7 +11,7 @@ Object checkpoint({
   return {
     'checkpoint': {
       'last_op_id': '$lastOpId',
-      'write_checkpoint': null,
+      'write_checkpoint': writeCheckpoint,
       'buckets': buckets,
       'streams': streams,
     }


### PR DESCRIPTION
Consider the following sequence of events:

1. The client is offline and mutates the database.
2. The client connects, and starts uploading changes.
3. That triggers a new checkpoint that gets synced down. It can't be applied because `$local.target_op` is at  1<<62.
4. The connector is done, the client SDK requests a write checkpoint.
4. We get a write checkpoint response, it's `1`.
6. Because the upload has finished, we send an `upload_completed` notification to the Rust client. That tries applying the previous checkpoint, which fails because it doesn't have a write checkpoint. A "Could not apply pending checkpoint even after completed upload" warning message is logged.
7. A new checkpoint with the write checkpoint is synced down and applied.

This is actually fairly common, and a completely harmless sequence of events that both the service and the client handle correctly. It's just the warning message that stands out here. So, this PR removes that message.

This also adds tests for:

1. The checkpoint containing a requested write checkpoint being synced before the crud upload task in SDKs completes (completing it should apply the checkpoint, recently handled correctly).
2. The crud upload completing and triggering a new checkpoint with the data and write checkpoint (we've always handled this one correctly).
3. Receiving a data checkpoint first and a write checkpoint later (there shouldn't be the annoying warning message).
4. A second local write after the first one has been uploaded (this should still trigger the warning message to notify developers about why the sync couldn't be completed).

Closes https://github.com/powersync-ja/powersync-kotlin/issues/243.