### PR TITLE
Prepare 0.5.3 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powersync_core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "const_format",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "powersync_core",
  "powersync_sqlite_nostd",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "cc",
  "powersync_core",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite_nostd"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bindgen",
  "num-derive 0.4.2",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_static"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "powersync_core",
  "powersync_sqlite_nostd",
@@ -645,7 +645,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sqlite3"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 inherits = "wasm"
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.powersync"
-version = "0.5.2"
+version = "0.5.3"
 description = "PowerSync Core SQLite Extension"
 
 val localRepo = uri("build/repository/")

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.5.2"
+  "version": "0.5.3"
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,7 +16,7 @@ name = "powersync_core"
 crate-type = ["rlib"]
 
 [dependencies]
-powersync_sqlite_nostd = { version = "=0.5.2", path = "../sqlite_nostd" }
+powersync_sqlite_nostd = { version = "=0.5.3", path = "../sqlite_nostd" }
 bytes = { version = "1.4", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 num-derive = "0.3"

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.5.2'
+  s.version          = '0.5.3'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -29,7 +29,7 @@ TARGETS=(
   aarch64-apple-tvos-sim
   x86_64-apple-tvos
 )
-VERSION=0.5.2
+VERSION=0.5.3
 
 function generatePlist() {
   min_os_version=0


### PR DESCRIPTION
This updates version numbers to 0.5.3 in the usual places. A summary of changes since the previous release:

1. Improve error messages to consistently include the internal statement that failed (https://github.com/powersync-ja/powersync-sqlite-core/pull/211).
2. Attest uploaded binaries with SLSA level 3, generate and attest an SBOM of Rust dependencies (https://github.com/powersync-ja/powersync-sqlite-core/pull/212).
3. Update Rust dependencies (https://github.com/powersync-ja/powersync-sqlite-core/pull/213).
4. Fix `tx_id` mismatch for transactions writing to regular and insert-only tables (https://github.com/powersync-ja/powersync-sqlite-core/pull/214). 
